### PR TITLE
The last row is accidentally made into a header row if you box in the table with extra divider lines

### DIFF
--- a/lib/org-ruby/parser.rb
+++ b/lib/org-ruby/parser.rb
@@ -88,6 +88,7 @@ module Orgmode
       @options = { }
       mode = :normal
       previous_line = nil
+      table_header_set = false
       @lines.each do |line|
         case mode
         when :normal
@@ -102,8 +103,12 @@ module Orgmode
               store_in_buffer_setting key, value
             end
             if line.table_separator? then
-              previous_line.assigned_paragraph_type = :table_header if previous_line and previous_line.paragraph_type == :table_row
+              if previous_line and previous_line.paragraph_type == :table_row and !table_header_set
+                previous_line.assigned_paragraph_type = :table_header
+                table_header_set = true
+              end
             end
+            table_header_set = false if !line.table?
             mode = :code if line.begin_block? and line.block_type == "EXAMPLE"
             if (@current_headline) then
               @current_headline.body_lines << line

--- a/spec/html_examples/tables.html
+++ b/spec/html_examples/tables.html
@@ -18,3 +18,18 @@
   <tr><td>Seven</td><td>Eight</td><td>Nine</td></tr>
 </table>
 <p>The separator row should not get printed out.</p>
+<h1>Table with complete box</h1>
+<table>
+  <tr><th>One</th><th>Two</th><th>Three</th></tr>
+  <tr><td>Four</td><td>Five</td><td>Six</td></tr>
+  <tr><td>Seven</td><td>Eight</td><td>Nine</td></tr>
+</table>
+<p>Only the first row should be a header row.</p>
+<h1>Table with extra lines</h1>
+<table>
+  <tr><th>One</th><th>Two</th><th>Three</th></tr>
+  <tr><td>Four</td><td>Five</td><td>Six</td></tr>
+  <tr><td>Seven</td><td>Eight</td><td>Nine</td></tr>
+  <tr><td>Ten</td><td>Eleven</td><td>Twelve</td></tr>
+</table>
+<p>Only the first row should be a header row.</p>

--- a/spec/html_examples/tables.org
+++ b/spec/html_examples/tables.org
@@ -24,3 +24,27 @@ Different types of ORG tables.
   | Seven | Eight | Nine  |
 
   The separator row should not get printed out.
+
+* Table with complete box
+
+  |-------+-------+-------|
+  | One   | Two   | Three |
+  |-------+-------+-------|
+  | Four  | Five  | Six   |
+  | Seven | Eight | Nine  |
+  |-------+-------+-------|
+
+  Only the first row should be a header row.
+
+* Table with extra lines
+
+  |-------+--------+--------|
+  | One   | Two    | Three  |
+  |-------+--------+--------|
+  | Four  | Five   | Six    |
+  | Seven | Eight  | Nine   |
+  |-------+--------+--------|
+  | Ten   | Eleven | Twelve |
+  |-------+--------+--------|
+
+  Only the first row should be a header row.

--- a/spec/textile_examples/tables.org
+++ b/spec/textile_examples/tables.org
@@ -24,3 +24,27 @@ Different types of ORG tables.
   | Seven | Eight | Nine  |
 
   The separator row should not get printed out.
+
+* Table with complete box
+
+  |-------+-------+-------|
+  | One   | Two   | Three |
+  |-------+-------+-------|
+  | Four  | Five  | Six   |
+  | Seven | Eight | Nine  |
+  |-------+-------+-------|
+
+  Only the first row should be a header row.
+
+* Table with extra lines
+
+  |-------+--------+--------|
+  | One   | Two    | Three  |
+  |-------+--------+--------|
+  | Four  | Five   | Six    |
+  | Seven | Eight  | Nine   |
+  |-------+--------+--------|
+  | Ten   | Eleven | Twelve |
+  |-------+--------+--------|
+
+  Only the first row should be a header row.

--- a/spec/textile_examples/tables.textile
+++ b/spec/textile_examples/tables.textile
@@ -21,3 +21,20 @@ h1. Table with header
 | Seven | Eight | Nine  |
 
 The separator row should not get printed out. 
+
+h1. Table with complete box
+
+| One   | Two   | Three |
+| Four  | Five  | Six   |
+| Seven | Eight | Nine  |
+
+Only the first row should be a header row. 
+
+h1. Table with extra lines
+
+| One   | Two    | Three  |
+| Four  | Five   | Six    |
+| Seven | Eight  | Nine   |
+| Ten   | Eleven | Twelve |
+
+Only the first row should be a header row. 


### PR DESCRIPTION
Here's a small tweak for more accurate table header support.  Org allows divider-type lines
around the table as well as inside the table while only creating one
header row.  E.g. the following will only have one header line:

```
  |-------+--------+--------|
  | One   | Two    | Three  |
  |-------+--------+--------|
  | Four  | Five   | Six    |
  | Seven | Eight  | Nine   |
  |-------+--------+--------|
  | Ten   | Eleven | Twelve |
  |-------+--------+--------|
```

Without the tweak, the rows starting with One, Seven, and Ten will be headers.
