### PR TITLE
Allow pretty text in links to be images.

### DIFF
--- a/lib/org-ruby/html_output_buffer.rb
+++ b/lib/org-ruby/html_output_buffer.rb
@@ -158,6 +158,9 @@ module Orgmode
         end
         link = link.sub(/^file:/i, "") # will default to HTTP
         link = link.sub(/\.org$/i, ".html")
+        text = text.gsub(/([^\]]*\.(jpg|jpeg|gif|png))/xi) do |link|
+          "<img src=\"#{link}\" />"
+        end
         "<a href=\"#{link}\">#{text}</a>"
       end
       if (@output_type == :table_row) then


### PR DESCRIPTION
The description text of URLs can now be images, hence enabling insertion of images which are enclosed in the anchor tag. 
