### PR TITLE
(1) Support angle links like <http://google.com>, (2) Omit Property drawer on the to_html output

### DIFF
--- a/lib/org-ruby/line.rb
+++ b/lib/org-ruby/line.rb
@@ -41,6 +41,26 @@ module Orgmode
       return @line =~ /^#/
     end
 
+    PropertyDrawerRegexp = /^\s*:(PROPERTIES|END):/i
+
+    def property_drawer_begin_block?
+      @line =~ PropertyDrawerRegexp && $1 =~ /PROPERTIES/
+    end
+
+    def property_drawer_end_block?
+      @line =~ PropertyDrawerRegexp && $1 =~ /END/
+    end
+
+    def property_drawer?
+      check_assignment_or_regexp(:property_drawer, PropertyDrawerRegexp)
+    end
+
+    PropertyDrawerItemRegexp = /^\s*:(\w+):\s*(.*)$/i
+
+    def property_drawer_item?
+      @line =~ PropertyDrawerItemRegexp
+    end
+
     # Tests if a line contains metadata instead of actual content.
     def metadata?
       check_assignment_or_regexp(:metadata, /^\s*(CLOCK|DEADLINE|START|CLOSED|SCHEDULED):/)
@@ -173,6 +193,9 @@ module Orgmode
       return :definition_list if definition_list? # order is important! A definition_list is also an unordered_list!
       return :ordered_list if ordered_list?
       return :unordered_list if unordered_list?
+      return :property_drawer_begin_block if property_drawer_begin_block?
+      return :property_drawer_end_block if property_drawer_end_block?
+      return :property_drawer_item if property_drawer_item?
       return :metadata if metadata?
       return :begin_block if begin_block?
       return :end_block if end_block?

--- a/lib/org-ruby/output_buffer.rb
+++ b/lib/org-ruby/output_buffer.rb
@@ -54,7 +54,7 @@ module Orgmode
       push_mode(:normal)
     end
 
-    Modes = [:normal, :ordered_list, :unordered_list, :definition_list, :blockquote, :src, :example, :table, :inline_example, :center]
+    Modes = [:normal, :ordered_list, :unordered_list, :definition_list, :blockquote, :src, :example, :table, :inline_example, :center, :property_drawer]
 
     def current_mode
       @mode_stack.last
@@ -84,8 +84,10 @@ module Orgmode
         maintain_list_indent_stack(line)
         @output_type = line.paragraph_type 
       end
-      push_mode(:inline_example) if line.inline_example? and current_mode != :inline_example
-      pop_mode(:inline_example) if current_mode == :inline_example && !line.inline_example?
+      push_mode(:inline_example) if line.inline_example? and current_mode != :inline_example and not line.property_drawer?
+      pop_mode(:inline_example) if current_mode == :inline_example and !line.inline_example?
+      push_mode(:property_drawer) if line.property_drawer? and current_mode != :property_drawer
+      pop_mode(:property_drawer) if current_mode == :property_drawer and line.property_drawer_end_block?
       push_mode(:table) if enter_table?
       pop_mode(:table) if exit_table?
       @buffered_lines.push(line)

--- a/lib/org-ruby/regexp_helper.rb
+++ b/lib/org-ruby/regexp_helper.rb
@@ -144,11 +144,17 @@ module Orgmode
       i = str.gsub(@org_link_regexp) do |match|
         yield $1, nil
       end
-      i.gsub(@org_link_text_regexp) do |match|
-        yield $1, $2
+      if str =~ @org_angle_link_text_regexp
+        i.gsub(@org_angle_link_text_regexp) do |match|
+          yield "#{$2}:#{$3}", nil
+        end
+      else
+        i.gsub(@org_link_text_regexp) do |match|
+          yield $1, $2
+        end
       end
     end
-    
+
     # Rewrites all of the inline image tags.
     def rewrite_images(str) #  :yields: image_link
       str.gsub(@org_img_regexp) do |match|
@@ -180,6 +186,7 @@ module Orgmode
                                \]\[
                                  ([^\]]*) # This is the friendly text
                                \]\]/x
+      @org_angle_link_text_regexp = /(<|&lt;)(\w+):([^\]\t\n\r<> ][^\]\t\n\r<> ]*)(>|&gt;)/x
     end
   end                           # class Emphasis
 end                             # module Orgmode


### PR DESCRIPTION
- Added some code to support angle links from org-mode.[1](https://github.com/bdewey/org-ruby/issues/8)
- Preliminar support of the property drawer block that goes below a headline (:PROPERTIES: ... :END:). 
  Now this is not shown on the output.

TODO: Testing 
