### PR TITLE
Add support for .org Tilt templates

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -16,6 +16,7 @@ extracting "content" from the orgfile as opposed to "metadata."
 * Supports tables, block quotes, and block code
 * Supports bold, italic, underline, strikethrough, and code inline formatting.
 * Supports hyperlinks that are in double-brackets
+* Supports +.org+ views in Rails through Tilt.
 * Upcoming: Handle export options specified in the org buffer.
 
 == SYNOPSIS:
@@ -34,7 +35,7 @@ From Ruby code:
 
      Orgmode::Parser.new(data)
 
-...will construct a new +Parser+ object. 
+...will construct a new +Parser+ object.
 
 == INSTALL:
 

--- a/lib/org-ruby/tilt.rb
+++ b/lib/org-ruby/tilt.rb
@@ -1,0 +1,29 @@
+begin
+  require 'tilt'
+
+  module Tilt
+    class OrgTemplate < Template
+      def self.engine_initialized?
+        defined? ::Orgmode
+      end
+
+      def initialize_engine
+        require 'org-ruby'
+      end
+
+      def prepare
+        @engine = Orgmode::Parser.new(data)
+        @output = nil
+      end
+
+      def evaluate(scope, locals, &block)
+        @output ||= @engine.to_html
+      end
+    end
+  end
+
+  Tilt.register Tilt::OrgTemplate, 'org'
+
+rescue LoadError
+  # Tilt is not available.
+end


### PR DESCRIPTION
This will allow people to use .org files as views in Rails, or as templates anywhere the Tilt template engine is used. I'm using this right now to generate a static site using [Stasis](http://stasis.me/). Not everyone on my dev team uses Emacs, so this allows us all to generate the static doc site.
