### PR TITLE
Fix for gollum issue #86

### DIFF
--- a/lib/org-ruby/html_output_buffer.rb
+++ b/lib/org-ruby/html_output_buffer.rb
@@ -215,7 +215,11 @@ module Orgmode
           "file:#{$1}"
         end
         link = link.sub(/^file:/i, "") # will default to HTTP
-        link = link.sub(/\.org$/i, ".html")
+        if (link.match(/:\/\/[^\/]*.org$/)) then
+          1;
+        else
+          link = link.sub(/\.org$/i, ".html")
+        end
         text = text.gsub(/([^\]]*\.(jpg|jpeg|gif|png))/xi) do |img_link|
           "<img src=\"#{img_link}\" />"
         end


### PR DESCRIPTION
http://foo.org URIs are now handled properly, rather than being
converted into http://foo.html links in the rendered output.

Signed-off-by: Ray Lehtiniemi rayl@mail.com

(tested with:
- [[http://foo.com][com website]]
- [[http://foo.org][org website]]
- [[http://foo.org/foo.org][org orgfile]]
- [[http://localhost:4567/foo.org][local orgfile]]
  )
