### PR TITLE
Correct parsing of org-mode emphasis

### DIFF
--- a/lib/org-ruby/regexp_helper.rb
+++ b/lib/org-ruby/regexp_helper.rb
@@ -52,11 +52,11 @@ module Orgmode
 
     def initialize
       # Set up the emphasis regular expression.
-      @pre_emphasis = " \t\\('\""
-      @post_emphasis = "- \t.,:!?;'\"\\)"
+      @pre_emphasis = " \t\\('\"\\{"
+      @post_emphasis = "- \t\\.,:!\\?;'\"\\)\\}\\\\"
       @border_forbidden = " \t\r\n,\"'"
       @body_regexp = ".*?"
-      @markers = "*/_=~+"
+      @markers = "\\*\\/_=~\\+"
       @logger = Logger.new(STDERR)
       @logger.level = Logger::WARN
       build_org_emphasis_regexp
@@ -97,7 +97,7 @@ module Orgmode
     def rewrite_emphasis(str)
       str.gsub(@org_emphasis_regexp) do |match|
         inner = yield $2, $3
-        "#{$1}#{inner}#{$4}"
+        "#{$1}#{inner}"
       end
     end
 
@@ -161,11 +161,11 @@ module Orgmode
 
     def build_org_emphasis_regexp
       @org_emphasis_regexp = Regexp.new("([#{@pre_emphasis}]|^)\n" +
-                                        "(  [#{@markers}]  )\n" +
-                                        "(  [^#{@border_forbidden}]  | " +
-                                        "  [^#{@border_forbidden}]#{@body_regexp}[^#{@border_forbidden}]  )\n" +
+                                        "( [#{@markers}] ) (?!\\2)\n" +
+                                        "( [^#{@border_forbidden}] | " +
+                                        "[^#{@border_forbidden}]#{@body_regexp}[^#{@border_forbidden}] )\n" +
                                         "\\2\n" +
-                                        "([#{@post_emphasis}]|$)\n", Regexp::EXTENDED)
+                                        "(?=[#{@post_emphasis}]|$)\n", Regexp::EXTENDED)
       @logger.debug "Just created regexp: #{@org_emphasis_regexp}"
     end
 


### PR DESCRIPTION
The code follows Emacs' org-mode parsing of emphasized text as close as possible. It relies on Emacs' org-mode code, which I enclose with slight modifications. I combine regexp `org-emph-re`

``` scheme
(setq org-emph-re
      (concat "\\([" pre "]\\|^\\)"
              "\\("
              "\\([" markers "]\\)"
              "\\("
              "[^" border "]\\|"
              "[^" border "]"
              body1
              "[^" border "]"
              "\\)"
              "\\3\\)"
              "\\([" post "]\\|$\\)"))
```

with emphazing procedure in `org-html.el`

``` scheme
(defun org-export-html-convert-emphasize (string)
  "Apply emphasis."
  (let ((s 0) rpl)
    (while (string-match org-emph-re string s)
      (if (not (equal
                ;; Return preceding marker
                (substring string (match-beginning 3) (1+ (match-beginning 3)))
                ;; Return char after preceding marker
                (substring string (match-beginning 4) (1+ (match-beginning 4)))))

          ;; If preceding marker and the following char are different
          ;; Set position `s' to the regexp beginning
          (setq s (match-beginning 0)
                rpl
                (concat
                 ;; Leave pre_emphasis unchanged
                 (match-string 1 string)
                 ;; Replace preceding marker by the corresponding open tag
                 (nth 2 (assoc (match-string 3 string) org-emphasis-alist))
                 ;; Leave body unchanged
                 (match-string 4 string)
                 ;; Replace posterior marker by the corresponding close tag
                 (nth 3 (assoc (match-string 3 string)
                               org-emphasis-alist))
                 ;; Leave post_emphasis unchanged
                 (match-string 5 string))
                ;; Incorporate changes into the primary string
                string (replace-match rpl t t string)
                ;; Adjust position `s' to the next regexp search
                s (+ s (- (length rpl) 2)))

        ;; If preceding marker and the following char are the same
        ;; Do nothing, go forward
        (setq s (1+ s))))
    string))
```

Newlines within emphasis follows from

``` scheme
(setq e org-emphasis-regexp-components)
(setq body (nth 3 e))
(setq nl (nth 4 e))
(setq body1 (concat body "*?"))

(if (> nl 0)
    (setq body1 (concat body1 "\\(?:\n" body "*?\\)\\{0,"
                        (int-to-string nl) "\\}")))
```
