### PR TITLE
Merge three methods **to_textile** into that one

### DIFF
--- a/lib/org-ruby/headline.rb
+++ b/lib/org-ruby/headline.rb
@@ -85,13 +85,6 @@ module Orgmode
       :"heading#{@level}"
     end
 
-    # Converts this headline and its body to textile.
-    def to_textile
-      output = "h#{@level}. #{@headline_text}\n"
-      output << Line.to_textile(@body_lines[1..-1])
-      output
-    end
-
     ######################################################################
     private
 

--- a/lib/org-ruby/line.rb
+++ b/lib/org-ruby/line.rb
@@ -223,12 +223,6 @@ module Orgmode
       return :paragraph
     end
 
-    def self.to_textile(lines)
-      output = ""
-      output_buffer = TextileOutputBuffer.new(output)
-      Parser.translate(lines, output_buffer)
-    end
-
     ######################################################################
     private
 

--- a/lib/org-ruby/parser.rb
+++ b/lib/org-ruby/parser.rb
@@ -158,7 +158,7 @@ module Orgmode
 
           line = Line.new line, self
           if line.end_block? and line.code_block?
-            mode = :normal            
+            mode = :normal
           else
             line.assigned_paragraph_type = :src
           end
@@ -195,9 +195,11 @@ module Orgmode
     # Saves the loaded orgmode file as a textile file.
     def to_textile
       output = ""
-      output << Line.to_textile(@header_lines)
+      output_buffer = TextileOutputBuffer.new(output)
+
+      Parser.translate(@header_lines, output_buffer)
       @headlines.each do |headline|
-        output << headline.to_textile
+        Parser.translate(headline.body_lines, output_buffer)
       end
       output
     end
@@ -248,6 +250,7 @@ module Orgmode
     # Converts an array of lines to the appropriate format.
     # Writes the output to +output_buffer+.
     def self.translate(lines, output_buffer)
+      output_buffer.output_type = :start
       lines.each do |line|
 
         # See if we're carrying paragraph payload, and output

--- a/lib/org-ruby/textile_output_buffer.rb
+++ b/lib/org-ruby/textile_output_buffer.rb
@@ -92,7 +92,13 @@ module Orgmode
             (@output_type == :definition_list and not @support_definition_list) then
           @output << "*" * @list_indent_stack.length << " "
         end
-        @output << inline_formatting(@buffer) << "\n"
+        if (@buffered_lines[0].kind_of?(Headline)) then
+          headline = @buffered_lines[0]
+          raise "Cannot be more than one headline!" if @buffered_lines.length > 1
+          @output << "h#{headline.level}. #{headline.headline_text}\n"
+        else
+          @output << inline_formatting(@buffer) << "\n"
+        end
       end
       clear_accumulation_buffer!
     end


### PR DESCRIPTION
As three objects (_Line_, _Headline_, _Parser_) use the same method **to_textile**, it is better to use only that one for a _Parser_ object in analogy with **to_html** method. Outputs of all examples from `spec/textile_examples` and `spec/html_examples` don't change.
