### PR TITLE
Fix error when table starts with hline

### DIFF
--- a/lib/org-ruby/parser.rb
+++ b/lib/org-ruby/parser.rb
@@ -99,15 +99,14 @@ module Orgmode
       mode = :normal
       previous_line = nil
       table_header_set = false
-      @lines.each do |line|
+      @lines.map { |line| Line.new line, self }.each do |line|
         case mode
         when :normal
 
-          if (Headline.headline? line) then
-            @current_headline = Headline.new line, self, offset
+          if (Headline.headline? line.line) then
+            @current_headline = Headline.new line.line, self, offset
             @headlines << @current_headline
           else
-            line = Line.new line, self
             # If there is a setting on this line, remember it.
             line.in_buffer_setting? do |key, value|
               store_in_buffer_setting key, value
@@ -131,7 +130,7 @@ module Orgmode
           end
 
         when :block_comment
-          line = Line.new line, self
+
           if line.end_block? and line.block_type == "COMMENT"
             mode = :normal
           else
@@ -142,7 +141,6 @@ module Orgmode
 
           # As long as we stay in code mode, force lines to be either blank or paragraphs.
           # Don't try to interpret structural items, like headings and tables.
-          line = Line.new line, self
           if line.end_block? and line.code_block?
             mode = :normal
           else
@@ -156,7 +154,6 @@ module Orgmode
 
         when :src_code
 
-          line = Line.new line, self
           if line.end_block? and line.code_block?
             mode = :normal            
           else
@@ -170,7 +167,6 @@ module Orgmode
 
         when :property_drawer
 
-          line = Line.new line, self
           if line.property_drawer_end_block?
             mode = :normal
           else
@@ -182,6 +178,7 @@ module Orgmode
             @header_lines << line
           end
         end                     # case
+
         previous_line = line
       end                       # @lines.each
     end                         # initialize

--- a/spec/data/tables.org
+++ b/spec/data/tables.org
@@ -1,0 +1,6 @@
+* a table with hline at the beginning
+|-----+-----|
+| foo | bar |
+|-----+-----|
+|   1 |   2 |
+* not a table

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -77,6 +77,15 @@ describe Orgmode::Parser do
     p.export_tables?.should be_false
   end
 
+  context "with a table that begins with a separator line" do
+    let(:parser) { Orgmode::Parser.new(data) }
+    let(:data) { Pathname.new(File.dirname(__FILE__)).join('data', 'tables.org').read }
+
+    it "should parse without errors" do
+      parser.headlines.size.should == 2
+    end
+  end
+
   describe "Custom keyword parser" do
     fname = File.join(File.dirname(__FILE__), %w[html_examples custom-todo.org])
     p = Orgmode::Parser.load(fname)


### PR DESCRIPTION
Fix exception that occurs when parsing a table that starts with an hline. Here's a message I found about someone seeing the same problem: http://lists.gnu.org/archive/html/emacs-orgmode/2010-04/msg00395.html
