### PR TITLE
Produce Textile and HTML outputs keeping newlines. RegexpHelper is modified, now it works better.

### DIFF
--- a/lib/org-ruby/html_output_buffer.rb
+++ b/lib/org-ruby/html_output_buffer.rb
@@ -88,7 +88,7 @@ module Orgmode
         # Need to close the floating li elements before closing the list
         if (m == :unordered_list or
             m == :ordered_list or
-            m == :definition_list) and 
+            m == :definition_list) and
             (not @unclosed_tags.empty?)
           close_floating_li_tags
         end
@@ -105,6 +105,7 @@ module Orgmode
     end
 
     def flush!
+      @buffer = @buffer.rstrip
       if buffer_mode_is_src_block?
 
         # Only try to colorize #+BEGIN_SRC blocks with a specified language,
@@ -166,7 +167,7 @@ module Orgmode
           unless buffer_mode_is_table? and skip_tables?
             @logger.debug "FLUSH      ==========> #{@buffer_mode}"
             output_indentation
-            if ((@buffered_lines[0].plain_list?) and 
+            if ((@buffered_lines[0].plain_list?) and
                 (@unclosed_tags.count == @list_indent_stack.count))
               @output << @unclosed_tags.pop
               output_indentation
@@ -189,9 +190,9 @@ module Orgmode
 
             # Only close the list when it is the last element from that list,
             # or when starting another list
-            if (@output_type == :unordered_list or 
+            if (@output_type == :unordered_list or
                 @output_type == :ordered_list   or
-                @output_type == :definition_list) and 
+                @output_type == :definition_list) and
                 (not @list_indent_stack.empty?)
               @unclosed_tags.push("</#{HtmlBlockTag[@output_type]}>\n")
               @output << "\n"

--- a/lib/org-ruby/parser.rb
+++ b/lib/org-ruby/parser.rb
@@ -278,23 +278,19 @@ module Orgmode
 
           output_buffer << line.line.lstrip
 
-        when :unordered_list, :ordered_list, :definition_list
+        when :unordered_list, :ordered_list, :definition_list, :src
 
-          output_buffer << line.output_text << " "
+          output_buffer << line.output_text << "\n"
 
         when :inline_example
 
           output_buffer << line.output_text
 
-        when :src
-
-          output_buffer << line.output_text << "\n"
-
         else
           if output_buffer.preserve_whitespace? then
             output_buffer << line.output_text
           else
-            output_buffer << line.output_text.strip << " "
+            output_buffer << line.output_text.strip << "\n"
           end
         end
       end

--- a/lib/org-ruby/regexp_helper.rb
+++ b/lib/org-ruby/regexp_helper.rb
@@ -39,13 +39,11 @@ module Orgmode
     # body-regexp  A regexp like \".\" to match a body character.  Don't use
     #              non-shy groups here, and don't allow newline here.
     # newline      The maximum number of newlines allowed in an emphasis exp.
-    #
-    # I currently don't use +newline+ because I've thrown this information
-    # away by this point in the code. TODO -- revisit?
     attr_reader   :pre_emphasis
     attr_reader   :post_emphasis
     attr_reader   :border_forbidden
     attr_reader   :body_regexp
+    attr_reader   :max_newlines
     attr_reader   :markers
 
     attr_reader   :org_emphasis_regexp
@@ -56,6 +54,9 @@ module Orgmode
       @post_emphasis = "- \t\\.,:!\\?;'\"\\)\\}\\\\"
       @border_forbidden = " \t\r\n,\"'"
       @body_regexp = ".*?"
+      @max_newlines = 1
+      @body_regexp = "#{@body_regexp}" +
+                     "(?:\n#{@body_regexp}){0,#{@max_newlines}}" if @max_newlines > 0
       @markers = "\\*\\/_=~\\+"
       @logger = Logger.new(STDERR)
       @logger.level = Logger::WARN
@@ -160,12 +161,12 @@ module Orgmode
     private
 
     def build_org_emphasis_regexp
-      @org_emphasis_regexp = Regexp.new("([#{@pre_emphasis}]|^)\n" +
-                                        "( [#{@markers}] ) (?!\\2)\n" +
-                                        "( [^#{@border_forbidden}] | " +
-                                        "[^#{@border_forbidden}]#{@body_regexp}[^#{@border_forbidden}] )\n" +
-                                        "\\2\n" +
-                                        "(?=[#{@post_emphasis}]|$)\n", Regexp::EXTENDED)
+      @org_emphasis_regexp = Regexp.new("([#{@pre_emphasis}]|^)" +
+                                        "([#{@markers}])(?!\\2)" +
+                                        "([^#{@border_forbidden}]|" +
+                                        "[^#{@border_forbidden}]#{@body_regexp}" +
+                                        "[^#{@border_forbidden}])\\2" +
+                                        "(?=[#{@post_emphasis}]|$)")
       @logger.debug "Just created regexp: #{@org_emphasis_regexp}"
     end
 

--- a/lib/org-ruby/textile_output_buffer.rb
+++ b/lib/org-ruby/textile_output_buffer.rb
@@ -74,6 +74,7 @@ module Orgmode
 
     # Flushes the current buffer
     def flush!
+      @buffer = @buffer.rstrip
       @logger.debug "FLUSH ==========> #{@output_type}"
       if (@output_type == :blank) then
         @output << "\n"

--- a/spec/html_examples/advanced-lists.html
+++ b/spec/html_examples/advanced-lists.html
@@ -23,7 +23,8 @@
   </ol>
   </li>
 </ul>
-<p>Note the list ends just some more text. Make sure both list blocks are closed.</p>
+<p>Note the list ends just some more text. Make sure both list blocks
+are closed.</p>
 <h1>Multi-paragraph list items</h1>
 <p>This list will end with the end-of-file. Make sure all blocks are closed.</p>
 <ul>

--- a/spec/html_examples/block_code.html
+++ b/spec/html_examples/block_code.html
@@ -1,5 +1,6 @@
 <h1 class="title">Block Code</h1>
-<p>I need to get block code examples working. In <code>orgmode</code>, they look like this:</p>
+<p>I need to get block code examples working. In <code>orgmode</code>, they look
+like this:</p>
 <pre class="example">
 
     def initialize(output)

--- a/spec/html_examples/code-comment.html
+++ b/spec/html_examples/code-comment.html
@@ -1,18 +1,19 @@
 <h1 class="title">Code Comment</h1>
-<p>I need to be able to export things that look like org-mode comments inside of code blocks, like this:</p>
+<p>I need to be able to export things that look like org-mode comments
+inside of code blocks, like this:</p>
 <pre class="example">
 #+TITLE:     orgmode_parser.org
-#+AUTHOR:    
+#+AUTHOR:
 #+EMAIL:     brian@BRIAN-DESK
 #+DATE:      2009-12-29 Tue
-#+DESCRIPTION: 
-#+KEYWORDS: 
+#+DESCRIPTION:
+#+KEYWORDS:
 #+LANGUAGE:  en
 #+OPTIONS:   H:3 num:t toc:nil \n:nil @:t ::t |:t ^:t -:t f:t *:t &lt;:t
 #+OPTIONS:   TeX:t LaTeX:nil skip:nil d:nil todo:t pri:nil tags:not-in-toc
 #+INFOJS_OPT: view:nil toc:nil ltoc:t mouse:underline buttons:0 path:http://orgmode.org/org-info.js
 #+EXPORT_SELECT_TAGS: export
 #+EXPORT_EXCLUDE_TAGS: noexport
-#+LINK_UP:   
-#+LINK_HOME: 
+#+LINK_UP:
+#+LINK_HOME:
 </pre>

--- a/spec/html_examples/code-lists.html
+++ b/spec/html_examples/code-lists.html
@@ -1,6 +1,7 @@
 <h1 class="title">normal list should work</h1>
 <ul>
-  <li>one text in the same line
+  <li>one
+text in the same line
   <p>This is a paragraph</p>
   <ul>
     <li>A sublist
@@ -68,7 +69,8 @@
 <ul>
   <li>Example
   <ul>
-    <li>Uno Lorem
+    <li>Uno
+Lorem
     <blockquote>
       <p>A quote!!!</p>
     </blockquote>
@@ -101,11 +103,13 @@
 <ul>
   <li>Example
   <dl>
-    <dt>Hello</dt><dd>Hola Paragrap continues here</dd>
+    <dt>Hello</dt><dd>Hola
+Paragrap continues here</dd>
     <blockquote>
       <p>Cuando me desperte, el dinosaurio estaba alli.</p>
     </blockquote>
-    <dt>Dog</dt><dd>Perro Paragraph</dd>
+    <dt>Dog</dt><dd>Perro
+Paragraph</dd>
     <li>Last sublist
     </li>
   </dl>

--- a/spec/html_examples/custom-seq-todo.html
+++ b/spec/html_examples/custom-seq-todo.html
@@ -1,10 +1,14 @@
 <p class="title">custom-todo.org</p>
-<p>I copied this todo sequence from Worg. It shows a lot of power of the built-in todo functionality. Now, let&#8217;s make sure all of these are recognized (and therefore NOT exported.)</p>
+<p>I copied this todo sequence from Worg. It shows a lot of power of the
+built-in todo functionality. Now, let&#8217;s make sure all of these are
+recognized (and therefore NOT exported.)</p>
 <h1><span class="todo-keyword TODO">TODO </span>Sample</h1>
 <ul>
-  <li>State &#8220;CANCELED&#8221;   from &#8220;INPROGRESS&#8221; [2009-12-29 Tue 22:26] &#92; I gave up.
+  <li>State &#8220;CANCELED&#8221;   from &#8220;INPROGRESS&#8221; [2009-12-29 Tue 22:26] &#92;
+I gave up.
   </li>
-  <li>State &#8220;WAITING&#8221;    from &#8220;&#8221;           [2009-12-29 Tue 22:25] &#92; huh?
+  <li>State &#8220;WAITING&#8221;    from &#8220;&#8221;           [2009-12-29 Tue 22:25] &#92;
+huh?
   </li>
 </ul>
 <h1><span class="todo-keyword INPROGRESS">INPROGRESS </span>this one&#8217;s in progress</h1>

--- a/spec/html_examples/custom-todo.html
+++ b/spec/html_examples/custom-todo.html
@@ -1,10 +1,14 @@
 <p class="title">custom-todo.org</p>
-<p>I copied this todo sequence from Worg. It shows a lot of power of the built-in todo functionality. Now, let&#8217;s make sure all of these are recognized (and therefore NOT exported.)</p>
+<p>I copied this todo sequence from Worg. It shows a lot of power of the
+built-in todo functionality. Now, let&#8217;s make sure all of these are
+recognized (and therefore NOT exported.)</p>
 <h1><span class="todo-keyword TODO">TODO </span>Sample</h1>
 <ul>
-  <li>State &#8220;CANCELED&#8221;   from &#8220;INPROGRESS&#8221; [2009-12-29 Tue 22:26] &#92; I gave up.
+  <li>State &#8220;CANCELED&#8221;   from &#8220;INPROGRESS&#8221; [2009-12-29 Tue 22:26] &#92;
+I gave up.
   </li>
-  <li>State &#8220;WAITING&#8221;    from &#8220;&#8221;           [2009-12-29 Tue 22:25] &#92; huh?
+  <li>State &#8220;WAITING&#8221;    from &#8220;&#8221;           [2009-12-29 Tue 22:25] &#92;
+huh?
   </li>
 </ul>
 <h1><span class="todo-keyword INPROGRESS">INPROGRESS </span>this one&#8217;s in progress</h1>

--- a/spec/html_examples/custom-typ-todo.html
+++ b/spec/html_examples/custom-typ-todo.html
@@ -1,10 +1,14 @@
 <p class="title">custom-todo.org</p>
-<p>I copied this todo sequence from Worg. It shows a lot of power of the built-in todo functionality. Now, let&#8217;s make sure all of these are recognized (and therefore NOT exported.)</p>
+<p>I copied this todo sequence from Worg. It shows a lot of power of the
+built-in todo functionality. Now, let&#8217;s make sure all of these are
+recognized (and therefore NOT exported.)</p>
 <h1><span class="todo-keyword TODO">TODO </span>Sample</h1>
 <ul>
-  <li>State &#8220;CANCELED&#8221;   from &#8220;INPROGRESS&#8221; [2009-12-29 Tue 22:26] &#92; I gave up.
+  <li>State &#8220;CANCELED&#8221;   from &#8220;INPROGRESS&#8221; [2009-12-29 Tue 22:26] &#92;
+I gave up.
   </li>
-  <li>State &#8220;WAITING&#8221;    from &#8220;&#8221;           [2009-12-29 Tue 22:25] &#92; huh?
+  <li>State &#8220;WAITING&#8221;    from &#8220;&#8221;           [2009-12-29 Tue 22:25] &#92;
+huh?
   </li>
 </ul>
 <h1><span class="todo-keyword INPROGRESS">INPROGRESS </span>this one&#8217;s in progress</h1>

--- a/spec/html_examples/emphasis.html
+++ b/spec/html_examples/emphasis.html
@@ -137,42 +137,78 @@ end
 
 all.each {|e| puts e}
 </pre>
-<p><b>Starting the line here *and continuing here to close*</b></p>
-<p><b>Starting the line here /and continuing here to close/</b></p>
-<p><b>Starting the line here =and continuing here to close=</b></p>
-<p><b>Starting the line here ~and continuing here to close~</b></p>
-<p><b>Starting the line here _and continuing here to close_</b></p>
-<p><b>Starting the line here +and continuing here to close+</b></p>
-<p><i>Starting the line here *and continuing here to close*</i></p>
-<p><i>Starting the line here /and continuing here to close/</i></p>
-<p><i>Starting the line here =and continuing here to close=</i></p>
-<p><i>Starting the line here ~and continuing here to close~</i></p>
-<p><i>Starting the line here _and continuing here to close_</i></p>
-<p><i>Starting the line here +and continuing here to close+</i></p>
-<p><code>Starting the line here *and continuing here to close*</code></p>
-<p><code>Starting the line here /and continuing here to close/</code></p>
-<p><code>Starting the line here =and continuing here to close=</code></p>
-<p><code>Starting the line here ~and continuing here to close~</code></p>
-<p><code>Starting the line here _and continuing here to close_</code></p>
-<p><code>Starting the line here +and continuing here to close+</code></p>
-<p><code>Starting the line here *and continuing here to close*</code></p>
-<p><code>Starting the line here /and continuing here to close/</code></p>
-<p><code>Starting the line here =and continuing here to close=</code></p>
-<p><code>Starting the line here ~and continuing here to close~</code></p>
-<p><code>Starting the line here _and continuing here to close_</code></p>
-<p><code>Starting the line here +and continuing here to close+</code></p>
-<p><span style="text-decoration:underline;">Starting the line here *and continuing here to close*</span></p>
-<p><span style="text-decoration:underline;">Starting the line here /and continuing here to close/</span></p>
-<p><span style="text-decoration:underline;">Starting the line here =and continuing here to close=</span></p>
-<p><span style="text-decoration:underline;">Starting the line here ~and continuing here to close~</span></p>
-<p><span style="text-decoration:underline;">Starting the line here _and continuing here to close_</span></p>
-<p><span style="text-decoration:underline;">Starting the line here +and continuing here to close+</span></p>
-<p><del>Starting the line here *and continuing here to close*</del></p>
-<p><del>Starting the line here /and continuing here to close/</del></p>
-<p><del>Starting the line here =and continuing here to close=</del></p>
-<p><del>Starting the line here ~and continuing here to close~</del></p>
-<p><del>Starting the line here _and continuing here to close_</del></p>
-<p><del>Starting the line here +and continuing here to close+</del></p>
+<p><b>Starting the line here
+*and continuing here to close*</b></p>
+<p><b>Starting the line here
+/and continuing here to close/</b></p>
+<p><b>Starting the line here
+=and continuing here to close=</b></p>
+<p><b>Starting the line here
+~and continuing here to close~</b></p>
+<p><b>Starting the line here
+_and continuing here to close_</b></p>
+<p><b>Starting the line here
++and continuing here to close+</b></p>
+<p><i>Starting the line here
+*and continuing here to close*</i></p>
+<p><i>Starting the line here
+/and continuing here to close/</i></p>
+<p><i>Starting the line here
+=and continuing here to close=</i></p>
+<p><i>Starting the line here
+~and continuing here to close~</i></p>
+<p><i>Starting the line here
+_and continuing here to close_</i></p>
+<p><i>Starting the line here
++and continuing here to close+</i></p>
+<p><code>Starting the line here
+*and continuing here to close*</code></p>
+<p><code>Starting the line here
+/and continuing here to close/</code></p>
+<p><code>Starting the line here
+=and continuing here to close=</code></p>
+<p><code>Starting the line here
+~and continuing here to close~</code></p>
+<p><code>Starting the line here
+_and continuing here to close_</code></p>
+<p><code>Starting the line here
++and continuing here to close+</code></p>
+<p><code>Starting the line here
+*and continuing here to close*</code></p>
+<p><code>Starting the line here
+/and continuing here to close/</code></p>
+<p><code>Starting the line here
+=and continuing here to close=</code></p>
+<p><code>Starting the line here
+~and continuing here to close~</code></p>
+<p><code>Starting the line here
+_and continuing here to close_</code></p>
+<p><code>Starting the line here
++and continuing here to close+</code></p>
+<p><span style="text-decoration:underline;">Starting the line here
+*and continuing here to close*</span></p>
+<p><span style="text-decoration:underline;">Starting the line here
+/and continuing here to close/</span></p>
+<p><span style="text-decoration:underline;">Starting the line here
+=and continuing here to close=</span></p>
+<p><span style="text-decoration:underline;">Starting the line here
+~and continuing here to close~</span></p>
+<p><span style="text-decoration:underline;">Starting the line here
+_and continuing here to close_</span></p>
+<p><span style="text-decoration:underline;">Starting the line here
++and continuing here to close+</span></p>
+<p><del>Starting the line here
+*and continuing here to close*</del></p>
+<p><del>Starting the line here
+/and continuing here to close/</del></p>
+<p><del>Starting the line here
+=and continuing here to close=</del></p>
+<p><del>Starting the line here
+~and continuing here to close~</del></p>
+<p><del>Starting the line here
+_and continuing here to close_</del></p>
+<p><del>Starting the line here
++and continuing here to close+</del></p>
 <h2>Multiline support test :: two lines</h2>
 <pre class="example">
 emphasis_tests = ["*","/","=","~","_","+"]
@@ -185,42 +221,114 @@ end
 
 all.each {|e| puts e}
 </pre>
-<p><b>Starting the line here *and continuing here to close*</b></p>
-<p><b>Starting the line here /and continuing here to close/</b></p>
-<p><b>Starting the line here =and continuing here to close=</b></p>
-<p><b>Starting the line here ~and continuing here to close~</b></p>
-<p><b>Starting the line here _and continuing here to close_</b></p>
-<p><b>Starting the line here +and continuing here to close+</b></p>
-<p><i>Starting the line here *and continuing here to close*</i></p>
-<p><i>Starting the line here /and continuing here to close/</i></p>
-<p><i>Starting the line here =and continuing here to close=</i></p>
-<p><i>Starting the line here ~and continuing here to close~</i></p>
-<p><i>Starting the line here _and continuing here to close_</i></p>
-<p><i>Starting the line here +and continuing here to close+</i></p>
-<p><code>Starting the line here *and continuing here to close*</code></p>
-<p><code>Starting the line here /and continuing here to close/</code></p>
-<p><code>Starting the line here =and continuing here to close=</code></p>
-<p><code>Starting the line here ~and continuing here to close~</code></p>
-<p><code>Starting the line here _and continuing here to close_</code></p>
-<p><code>Starting the line here +and continuing here to close+</code></p>
-<p><code>Starting the line here *and continuing here to close*</code></p>
-<p><code>Starting the line here /and continuing here to close/</code></p>
-<p><code>Starting the line here =and continuing here to close=</code></p>
-<p><code>Starting the line here ~and continuing here to close~</code></p>
-<p><code>Starting the line here _and continuing here to close_</code></p>
-<p><code>Starting the line here +and continuing here to close+</code></p>
-<p><span style="text-decoration:underline;">Starting the line here *and continuing here to close*</span></p>
-<p><span style="text-decoration:underline;">Starting the line here /and continuing here to close/</span></p>
-<p><span style="text-decoration:underline;">Starting the line here =and continuing here to close=</span></p>
-<p><span style="text-decoration:underline;">Starting the line here ~and continuing here to close~</span></p>
-<p><span style="text-decoration:underline;">Starting the line here _and continuing here to close_</span></p>
-<p><span style="text-decoration:underline;">Starting the line here +and continuing here to close+</span></p>
-<p><del>Starting the line here *and continuing here to close*</del></p>
-<p><del>Starting the line here /and continuing here to close/</del></p>
-<p><del>Starting the line here =and continuing here to close=</del></p>
-<p><del>Starting the line here ~and continuing here to close~</del></p>
-<p><del>Starting the line here _and continuing here to close_</del></p>
-<p><del>Starting the line here +and continuing here to close+</del></p>
+<p>*Starting the line here
+<b>and continuing here
+to close*</b></p>
+<p>*Starting the line here
+/and continuing here
+to close/*</p>
+<p>*Starting the line here
+=and continuing here
+to close=*</p>
+<p>*Starting the line here
+~and continuing here
+to close~*</p>
+<p>*Starting the line here
+_and continuing here
+to close_*</p>
+<p>*Starting the line here
++and continuing here
+to close+*</p>
+<p>/Starting the line here
+*and continuing here
+to close*/</p>
+<p>/Starting the line here
+<i>and continuing here
+to close/</i></p>
+<p>/Starting the line here
+=and continuing here
+to close=/</p>
+<p>/Starting the line here
+~and continuing here
+to close~/</p>
+<p>/Starting the line here
+_and continuing here
+to close_/</p>
+<p>/Starting the line here
++and continuing here
+to close+/</p>
+<p>=Starting the line here
+*and continuing here
+to close*=</p>
+<p>=Starting the line here
+/and continuing here
+to close/=</p>
+<p>=Starting the line here
+<code>and continuing here
+to close=</code></p>
+<p>=Starting the line here
+~and continuing here
+to close~=</p>
+<p>=Starting the line here
+_and continuing here
+to close_=</p>
+<p>=Starting the line here
++and continuing here
+to close+=</p>
+<p>~Starting the line here
+*and continuing here
+to close*~</p>
+<p>~Starting the line here
+/and continuing here
+to close/~</p>
+<p>~Starting the line here
+=and continuing here
+to close=~</p>
+<p>~Starting the line here
+<code>and continuing here
+to close~</code></p>
+<p>~Starting the line here
+_and continuing here
+to close_~</p>
+<p>~Starting the line here
++and continuing here
+to close+~</p>
+<p>_Starting the line here
+*and continuing here
+to close*_</p>
+<p>_Starting the line here
+/and continuing here
+to close/_</p>
+<p>_Starting the line here
+=and continuing here
+to close=_</p>
+<p>_Starting the line here
+~and continuing here
+to close~_</p>
+<p>_Starting the line here
+<span style="text-decoration:underline;">and continuing here
+to close_</span></p>
+<p>_Starting the line here
++and continuing here
+to close+_</p>
+<p>+Starting the line here
+*and continuing here
+to close*+</p>
+<p>+Starting the line here
+/and continuing here
+to close/+</p>
+<p>+Starting the line here
+=and continuing here
+to close=+</p>
+<p>+Starting the line here
+~and continuing here
+to close~+</p>
+<p>+Starting the line here
+_and continuing here
+to close_+</p>
+<p>+Starting the line here
+<del>and continuing here
+to close+</del></p>
 <h2>Together in same paragraph test</h2>
 <p><b>bold</b> <b>bold</b> <b>bold</b></p>
 <p><i>italic</i> <b>bold</b> <i>italic</i></p>

--- a/spec/html_examples/entities.html
+++ b/spec/html_examples/entities.html
@@ -1,4 +1,7 @@
 <p class="title">ENTITIES</p>
-<p><code>Org-ruby</code> supports &#8220;smart double quotes,&#8221; &#8216;smart single quotes,&#8217; apostrophes for contractions like won&#8217;t and can&#8217;t, and other things&#8230; like elipses. Oh &#8211; and dashes.</p>
-<p>Question: What does org-mode do for ampersands, like R&amp;R? or &amp;lt;? Answer: Those get escaped, too.</p>
+<p><code>Org-ruby</code> supports &#8220;smart double quotes,&#8221; &#8216;smart single quotes,&#8217;
+apostrophes for contractions like won&#8217;t and can&#8217;t, and other
+things&#8230; like elipses. Oh &#8211; and dashes.</p>
+<p>Question: What does org-mode do for ampersands, like R&amp;R? or &amp;lt;?
+Answer: Those get escaped, too.</p>
 <h1>&lt;Even in headlines! funner &amp; funner!&gt;</h1>

--- a/spec/html_examples/escape-pre.html
+++ b/spec/html_examples/escape-pre.html
@@ -1,6 +1,6 @@
 <pre class="example">
-&lt;li&gt;[ ] &amp;#8220;smart quotes&amp;#8221;&lt;/li&gt; 
-&lt;li&gt;[ ] I think I need this for &amp;#8216;single quotes&amp;#8217; too. Don&amp;#8217;t I?&lt;/li&gt; 
-&lt;li&gt;[ ] Em dashes would be great &amp;#8212; wouldn&amp;#8217;t they?&lt;/li&gt; 
-&lt;li&gt;[ ] I hope to develop an en dash sometime in 2010 &amp;#8211; 2011.&lt;/li&gt; 
+&lt;li&gt;[ ] &amp;#8220;smart quotes&amp;#8221;&lt;/li&gt;
+&lt;li&gt;[ ] I think I need this for &amp;#8216;single quotes&amp;#8217; too. Don&amp;#8217;t I?&lt;/li&gt;
+&lt;li&gt;[ ] Em dashes would be great &amp;#8212; wouldn&amp;#8217;t they?&lt;/li&gt;
+&lt;li&gt;[ ] I hope to develop an en dash sometime in 2010 &amp;#8211; 2011.&lt;/li&gt;
 </pre>

--- a/spec/html_examples/export-exclude-only.html
+++ b/spec/html_examples/export-exclude-only.html
@@ -6,7 +6,21 @@
 <h3><span class="heading-number heading-number-3">1.1.1 </span>Headline 3</h3>
 <p>This bit of body gets exported.</p>
 <h4><span class="heading-number heading-number-4">1.1.1.1 </span>Headline 4 (include)</h4>
-<p>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.</p>
+<p>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam
+nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam
+erat, sed diam voluptua. At vero eos et accusam et justo duo
+dolores et ea rebum. Stet clita kasd gubergren, no sea takimata
+sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit
+amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor
+invidunt ut labore et dolore magna aliquyam erat, sed diam
+voluptua. At vero eos et accusam et justo duo dolores et ea
+rebum. Stet clita kasd gubergren, no sea takimata sanctus est
+Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet,
+consetetur sadipscing elitr, sed diam nonumy eirmod tempor
+invidunt ut labore et dolore magna aliquyam erat, sed diam
+voluptua. At vero eos et accusam et justo duo dolores et ea
+rebum. Stet clita kasd gubergren, no sea takimata sanctus est
+Lorem ipsum dolor sit amet.</p>
 <h3><span class="heading-number heading-number-3">1.1.2 </span>Another headline 3</h3>
 <p>This one <b>should not</b> get exported!!</p>
 <h4><span class="heading-number heading-number-4">1.1.2.1 </span>Another headline 4</h4>

--- a/spec/html_examples/export-tags.html
+++ b/spec/html_examples/export-tags.html
@@ -5,4 +5,18 @@
 <h3><span class="heading-number heading-number-3">1.1.1 </span>Headline 3</h3>
 <p>This bit of body gets exported.</p>
 <h4><span class="heading-number heading-number-4">1.1.1.1 </span>Headline 4 (include)</h4>
-<p>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.</p>
+<p>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam
+nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam
+erat, sed diam voluptua. At vero eos et accusam et justo duo
+dolores et ea rebum. Stet clita kasd gubergren, no sea takimata
+sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit
+amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor
+invidunt ut labore et dolore magna aliquyam erat, sed diam
+voluptua. At vero eos et accusam et justo duo dolores et ea
+rebum. Stet clita kasd gubergren, no sea takimata sanctus est
+Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet,
+consetetur sadipscing elitr, sed diam nonumy eirmod tempor
+invidunt ut labore et dolore magna aliquyam erat, sed diam
+voluptua. At vero eos et accusam et justo duo dolores et ea
+rebum. Stet clita kasd gubergren, no sea takimata sanctus est
+Lorem ipsum dolor sit amet.</p>

--- a/spec/html_examples/export-title.html
+++ b/spec/html_examples/export-title.html
@@ -1,2 +1,3 @@
 <p class="title">Export Title</p>
-<p>This simple org document should get a title from the <code>TITLE</code> option at the front of the file.</p>
+<p>This simple org document should get a title from the <code>TITLE</code> option at
+the front of the file.</p>

--- a/spec/html_examples/footnotes.html
+++ b/spec/html_examples/footnotes.html
@@ -1,5 +1,6 @@
 <p class="title">Footnotes</p>
-<p>Hello<sup><a class="footref" name="fnr.abc" href="#fn.abc">abc</a></sup> World<sup><a class="footref" name="fnr.abc" href="#fn.abc">abc</a></sup></p>
+<p>Hello<sup><a class="footref" name="fnr.abc" href="#fn.abc">abc</a></sup>
+World<sup><a class="footref" name="fnr.abc" href="#fn.abc">abc</a></sup></p>
 <p>Bfoo<sup><a class="footref" name="fnr.1" href="#fn.1">1</a></sup></p>
 <div id="footnotes">
 <h2 class="footnotes">Footnotes: </h2>

--- a/spec/html_examples/html-literal.html
+++ b/spec/html_examples/html-literal.html
@@ -1,2 +1,4 @@
 <p class="title">HTML literals</p>
-<p>ORG escapes HTML by default. This should &lt;b&gt;not be bold text!&lt;/b&gt; Instead, it should look like regular text with some HTML tags around it.</p>
+<p>ORG escapes HTML by default. This should &lt;b&gt;not be bold text!&lt;/b&gt;
+Instead, it should look like regular text with some HTML tags around
+it.</p>

--- a/spec/html_examples/inline-formatting.html
+++ b/spec/html_examples/inline-formatting.html
@@ -1,6 +1,8 @@
 <p class="title">Inline Formatting</p>
-<p>I want to make sure I handle all inline formatting. I need to handle <b>bold</b>, <i>italic</i>, <code>code</code>, <code>verbatim</code>, <span style="text-decoration:underline;">underline</span>, <del>strikethrough</del>.</p>
-<p>In addition, I need to make sure I can handle links. We&#8217;ve got simple links, like this:</p>
+<p>I want to make sure I handle all inline formatting. I need to handle
+<b>bold</b>, <i>italic</i>, <code>code</code>, <code>verbatim</code>, <span style="text-decoration:underline;">underline</span>, <del>strikethrough</del>.</p>
+<p>In addition, I need to make sure I can handle links. We&#8217;ve got simple
+links, like this:</p>
 <ul>
   <li><a href="http://www.bing.com">http://www.bing.com</a>
   </li>
@@ -9,20 +11,25 @@
   <li>http://www.gmail.com
   </li>
 </ul>
-<p>Note the last one <b>is not</b> a link, as the source doesn&#8217;t include it in double-brackets and I don&#8217;t auto-recognize URLs.</p>
+<p>Note the last one <b>is not</b> a link, as the source doesn&#8217;t include it in
+double-brackets and I don&#8217;t auto-recognize URLs.</p>
 <p>I should also handle links with <a href="http://www.xkcd.com">helpful text</a>.</p>
-<p>Helpful addition from <a href="https://github.com/punchagan">punchagan</a>, we now recognize when the link goes to an image and make the link anchor be the image, like this:</p>
+<p>Helpful addition from <a href="https://github.com/punchagan">punchagan</a>, we now
+recognize when the link goes to an image and make the link anchor be the
+image, like this:</p>
 <ul>
   <li><a href="http://farm7.static.flickr.com/6078/6084185195_552aa270b2.jpg"><img src="http://farm7.static.flickr.com/6078/6084185195_552aa270b2.jpg" /></a>
   </li>
 </ul>
-<p>Also, if you make the descriptive text be an image, then it will get formatted with an image tag, like so:</p>
+<p>Also, if you make the descriptive text be an image, then it will get formatted
+with an image tag, like so:</p>
 <ul>
   <li><a href="http://www.xkcd.com"><img src="http://imgs.xkcd.com/comics/t_cells.png" /></a>
   </li>
 </ul>
 <p>Helpful addition from <a href="https://github.com/wallyqs">wallyqs</a>:</p>
-<p>While &#8220;naked&#8221; links don&#8217;t work (like http://www.google.com), angle links do work. This should look like a link: <a href="http://www.google.com">http://www.google.com</a>.</p>
+<p>While &#8220;naked&#8221; links don&#8217;t work (like http://www.google.com), angle links
+do work. This should look like a link: <a href="http://www.google.com">http://www.google.com</a>.</p>
 <p>It should be possible to use both kind of links on the same paragraph:</p>
 <p>This is an angle link <a href="http://google.com">http://google.com</a> and this is a bracket link <a href="https://github.com/bdewey/org-ruby">to a repository</a>.</p>
 <p>This is a bracket link <a href="https://github.com/bdewey/org-ruby">to a repository</a> and this is an angle link <a href="http://google.com">http://google.com</a>.</p>

--- a/spec/html_examples/inline-images.html
+++ b/spec/html_examples/inline-images.html
@@ -1,7 +1,9 @@
 <p class="title">Inline Images</p>
-<p>Per the org-mode <a href="http://orgmode.org/manual/Images-and-tables.html#Images-and-tables">spec</a>, you can include inline images as links without any descriptive link text, like this:</p>
+<p>Per the org-mode <a href="http://orgmode.org/manual/Images-and-tables.html#Images-and-tables">spec</a>, you can include inline images as links without
+any descriptive link text, like this:</p>
 <p><a href="http://farm5.static.flickr.com/4049/4358074549_5efb8b4903.jpg"><img src="http://farm5.static.flickr.com/4049/4358074549_5efb8b4903.jpg" /></a></p>
-<p>I currently do not support the caption/link syntax, but I can include the inline image. I recognize the following image file types:</p>
+<p>I currently do not support the caption/link syntax, but I can include
+the inline image. I recognize the following image file types:</p>
 <ul>
   <li>.jpg
   </li>

--- a/spec/html_examples/link-features.html
+++ b/spec/html_examples/link-features.html
@@ -1,7 +1,11 @@
 <p class="title">link-features.org</p>
-<p>Org-mode export supports a lot of link features. I&#8217;ve covered &#8220;simple&#8221; HTML links elsewhere. Now let&#8217;s cover links to other org files, other sections within documents, etc.</p>
+<p>Org-mode export supports a lot of link features. I&#8217;ve covered &#8220;simple&#8221;
+HTML links elsewhere. Now let&#8217;s cover links to other org files, other
+sections within documents, etc.</p>
 <h1>Links to other org files</h1>
-<p>This is a link to the <code>code-comment.org</code> file in the same directory. In <code>emacs</code>, if you click it, the other file opens. We want the same behavior in the HTML export.</p>
+<p>This is a link to the <code>code-comment.org</code> file in the same
+directory. In <code>emacs</code>, if you click it, the other file opens. We
+want the same behavior in the HTML export.</p>
 <p><a href="code-comment.html">Code Comment</a></p>
 <h1>Search links</h1>
 <p>This is a search link into code-comment.org.</p>

--- a/spec/html_examples/lists.html
+++ b/spec/html_examples/lists.html
@@ -11,9 +11,24 @@
 <ul>
   <li>This is a single-line list item in the org file.
   </li>
-  <li>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.
+  <li>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam
+nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam
+erat, sed diam voluptua. At vero eos et accusam et justo duo
+dolores et ea rebum. Stet clita kasd gubergren, no sea takimata
+sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit
+amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor
+invidunt ut labore et dolore magna aliquyam erat, sed diam
+voluptua. At vero eos et accusam et justo duo dolores et ea
+rebum. Stet clita kasd gubergren, no sea takimata sanctus est
+Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet,
+consetetur sadipscing elitr, sed diam nonumy eirmod tempor
+invidunt ut labore et dolore magna aliquyam erat, sed diam
+voluptua. At vero eos et accusam et justo duo dolores et ea
+rebum. Stet clita kasd gubergren, no sea takimata sanctus est
+Lorem ipsum dolor sit amet.
   </li>
-  <li>And this is the next item. The previous item needs to be on one line to keep <code>textile</code> happy.
+  <li>And this is the next item. The previous item needs to be on one
+line to keep <code>textile</code> happy.
   </li>
   <li>Ditto the previous line, actually.
   </li>
@@ -23,8 +38,12 @@
   <li>This is a single-line list.
   </li>
 </ul>
-<p>And this is a <b>separate paragraph.</b> Note the indentation in the org file.</p>
+<p>And this is a <b>separate paragraph.</b> Note the indentation in the org
+file.</p>
 <h2>Invalid lists</h2>
-<p>Note that spaces are required to denote lists. Thus, none of the following should get recognized as lists.</p>
-<p>-This isn&#8217;t a list. -And this isn&#8217;t a list.</p>
-<p>1.And this isn&#8217;t a list. 2.And this isn&#8217;t a list.</p>
+<p>Note that spaces are required to denote lists. Thus, none of the following
+should get recognized as lists.</p>
+<p>-This isn&#8217;t a list.
+-And this isn&#8217;t a list.</p>
+<p>1.And this isn&#8217;t a list.
+2.And this isn&#8217;t a list.</p>

--- a/spec/html_examples/metadata-comment.html
+++ b/spec/html_examples/metadata-comment.html
@@ -1,5 +1,6 @@
 <h1 class="title">Metadata, etc.</h1>
-<p>I normally filter out things that look like metadata. Can&#8217;t do it any more. I need to see all of the following:</p>
+<p>I normally filter out things that look like metadata. Can&#8217;t do it any
+more. I need to see all of the following:</p>
 <pre class="example">
 * DONE Handle inline formatting
   CLOSED: [2009-12-26 Sat 21:41]

--- a/spec/html_examples/skip-table.html
+++ b/spec/html_examples/skip-table.html
@@ -1,4 +1,5 @@
 <p class="title">skip-table.org</p>
 <p>Checking that tables are skipped when directed.</p>
-<p>For grins, here&#8217;s another table without a header. Just keep the bases covered.</p>
+<p>For grins, here&#8217;s another table without a header. Just keep the bases
+covered.</p>
 <p>Again, in the HTML output, you should see <b>no tables</b>.</p>

--- a/spec/html_examples/tables.html
+++ b/spec/html_examples/tables.html
@@ -10,7 +10,8 @@
   <tr><td>Cell one</td></tr>
   <tr><td>Cell two</td></tr>
 </table>
-<p>And here&#8217;s some paragraph content. The line breaks will need to get removed here, but not for the tables.</p>
+<p>And here&#8217;s some paragraph content. The line breaks will need to get
+removed here, but not for the tables.</p>
 <h1>Table with header</h1>
 <table>
   <tr><th>One</th><th>Two</th><th>Three</th></tr>

--- a/spec/html_examples/text.html
+++ b/spec/html_examples/text.html
@@ -1,2 +1,15 @@
 <p class="title">The simplest case: translating plain text.</p>
-<p>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet.</p>
+<p>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam
+nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat,
+sed diam voluptua. At vero eos et accusam et justo duo dolores et ea
+rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem
+ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur
+sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et
+dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam
+et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea
+takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit
+amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor
+invidunt ut labore et dolore magna aliquyam erat, sed diam
+voluptua. At vero eos et accusam et justo duo dolores et ea
+rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem
+ipsum dolor sit amet.</p>

--- a/spec/textile_examples/block_code.textile
+++ b/spec/textile_examples/block_code.textile
@@ -1,6 +1,7 @@
 h1. Block Code
 
-I need to get block code examples working. In @orgmode@, they look like this: 
+I need to get block code examples working. In @orgmode@, they look
+like this:
 
 bc.. 
     def initialize(output)
@@ -15,15 +16,15 @@ bc..
     end
 
 
-p. And now I should be back to normal text. 
+p. And now I should be back to normal text.
 
-Putting in another paragraph for good measure. 
+Putting in another paragraph for good measure.
 
-Code should also get cancelled by a list, thus: 
+Code should also get cancelled by a list, thus:
 
 bc.. This is my code!
 
 Another line!
 
-* My list should cancel this. 
-* Another list line. 
+* My list should cancel this.
+* Another list line.

--- a/spec/textile_examples/blockquote.textile
+++ b/spec/textile_examples/blockquote.textile
@@ -1,11 +1,11 @@
-BLOCKQUOTE 
+BLOCKQUOTE
 
-Testing that I can have block quotes: 
-
-
-bq. _Example:_ 
-
-bq. This is blockquote text. 
+Testing that I can have block quotes:
 
 
-And now I'm back to normal text! 
+bq. _Example:_
+
+bq. This is blockquote text.
+
+
+And now I'm back to normal text!

--- a/spec/textile_examples/center.textile
+++ b/spec/textile_examples/center.textile
@@ -1,6 +1,6 @@
 
-not center 
+not center
 
-p=. center 
+p=. center
 
-not center, again 
+not center, again

--- a/spec/textile_examples/footnotes.textile
+++ b/spec/textile_examples/footnotes.textile
@@ -1,8 +1,9 @@
 
-Hello[833038373] World[833038373] 
+Hello[4500512458992657954]
+World[4500512458992657954]
 
-Bfoo[1] 
+Bfoo[1]
+
+fn4500512458992657954. definition of abc
 
 fn1. *blub*
-
-fn833038373. definition of abc

--- a/spec/textile_examples/keywords.textile
+++ b/spec/textile_examples/keywords.textile
@@ -1,11 +1,12 @@
-KEYWORDS 
+KEYWORDS
 
-By default, I don't want keywords exported to textile. 
+By default, I don't want keywords exported to textile.
 
 h1. Recognize standard keywords
 
-The standard @orgmode@ keywords are TODO and DONE. Recognize those. 
+The standard @orgmode@ keywords are TODO and DONE. Recognize those.
 
 h1. Recongize buffer-specific keywords
 
-There's a way to define a custom keyword list in a buffer. Research that and handle it. 
+There's a way to define a custom keyword list in a buffer. Research
+that and handle it.

--- a/spec/textile_examples/links.textile
+++ b/spec/textile_examples/links.textile
@@ -1,10 +1,10 @@
-LINKS 
+LINKS
 
-"http://www.bing.com":http://www.bing.com 
+"http://www.bing.com":http://www.bing.com
 
 h1. Supported Link Styles
 
-* "http://www.hotmail.com":http://www.hotmail.com => Simple 
-* "Hotmail":http://www.hotmail.com => With link text 
-* "with spaces":http://url/with%20spaces 
-* "http://url/with spaces":http://url/with%20spaces 
+* "http://www.hotmail.com":http://www.hotmail.com => Simple
+* "Hotmail":http://www.hotmail.com => With link text
+* "with spaces":http://url/with%20spaces
+* "http://url/with spaces":http://url/with%20spaces

--- a/spec/textile_examples/lists.textile
+++ b/spec/textile_examples/lists.textile
@@ -1,20 +1,36 @@
 h1. Lists
 
-I want to make sure I have great support for lists. 
+I want to make sure I have great support for lists.
 
-* This is an unordered list 
-* This continues the unordered list 
+* This is an unordered list
+* This continues the unordered list
 
-And this is a paragraph *after* the list. 
+And this is a paragraph *after* the list.
 
 h2. Wrapping within the list
 
-* This is a single-line list item in the org file. 
-* Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat, sed diam voluptua. At vero eos et accusam et justo duo dolores et ea rebum. Stet clita kasd gubergren, no sea takimata sanctus est Lorem ipsum dolor sit amet. 
-* And this is the next item. The previous item needs to be on one line to keep @textile@ happy. 
-* Ditto the previous line, actually. 
+* This is a single-line list item in the org file.
+* Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam
+nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam
+erat, sed diam voluptua. At vero eos et accusam et justo duo
+dolores et ea rebum. Stet clita kasd gubergren, no sea takimata
+sanctus est Lorem ipsum dolor sit amet. Lorem ipsum dolor sit
+amet, consetetur sadipscing elitr, sed diam nonumy eirmod tempor
+invidunt ut labore et dolore magna aliquyam erat, sed diam
+voluptua. At vero eos et accusam et justo duo dolores et ea
+rebum. Stet clita kasd gubergren, no sea takimata sanctus est
+Lorem ipsum dolor sit amet. Lorem ipsum dolor sit amet,
+consetetur sadipscing elitr, sed diam nonumy eirmod tempor
+invidunt ut labore et dolore magna aliquyam erat, sed diam
+voluptua. At vero eos et accusam et justo duo dolores et ea
+rebum. Stet clita kasd gubergren, no sea takimata sanctus est
+Lorem ipsum dolor sit amet.
+* And this is the next item. The previous item needs to be on one
+line to keep @textile@ happy.
+* Ditto the previous line, actually.
 
 h2. Edge cases
 
-* This is a single-line list. 
-And this is a *separate paragraph.* Note the indentation in the org file. 
+* This is a single-line list.
+And this is a *separate paragraph.* Note the indentation in the org
+file.

--- a/spec/textile_examples/single-space-plain-list.textile
+++ b/spec/textile_examples/single-space-plain-list.textile
@@ -1,10 +1,13 @@
 h2. Anatomy of a BVP
 
-Each BVP followed a simple, one-page template with the following parts: 
+Each BVP followed a simple, one-page template with the following
+parts:
 
-* Customer Summary 
-* Storyboard 
-* Requirements 
-* Partner teams 
+* Customer Summary
+* Storyboard
+* Requirements
+* Partner teams
 
-The following sections walk through each section and give an example from one of our BVPs, "Resource-Smart Virtualization Infrastructure":http://windows/hyper-v/initiatives/Value%20Propositions/DynamicDatacenter-ValueProp.docx (also called _Dynamic Datacenter_). 
+The following sections walk through each section and give an
+example from one of our BVPs, "Resource-Smart Virtualization
+Infrastructure":http://windows/hyper-v/initiatives/Value%20Propositions/DynamicDatacenter-ValueProp.docx (also called _Dynamic Datacenter_).

--- a/spec/textile_examples/tables.textile
+++ b/spec/textile_examples/tables.textile
@@ -1,6 +1,6 @@
-TABLES 
+TABLES
 
-Different types of ORG tables. 
+Different types of ORG tables.
 
 h1. Simple table, no header.
 
@@ -12,7 +12,8 @@ h1. Indented table
 | Cell one |
 | Cell two |
 
-And here's some paragraph content. The line breaks will need to get removed here, but not for the tables. 
+And here's some paragraph content. The line breaks will need to get
+removed here, but not for the tables.
 
 h1. Table with header
 
@@ -20,7 +21,7 @@ h1. Table with header
 | Four  | Five  | Six   |
 | Seven | Eight | Nine  |
 
-The separator row should not get printed out. 
+The separator row should not get printed out.
 
 h1. Table with complete box
 
@@ -28,7 +29,7 @@ h1. Table with complete box
 | Four  | Five  | Six   |
 | Seven | Eight | Nine  |
 
-Only the first row should be a header row. 
+Only the first row should be a header row.
 
 h1. Table with extra lines
 
@@ -37,4 +38,4 @@ h1. Table with extra lines
 | Seven | Eight  | Nine   |
 | Ten   | Eleven | Twelve |
 
-Only the first row should be a header row. 
+Only the first row should be a header row.


### PR DESCRIPTION
I modified code with goal to safe newlines within text, which is utilized in most text conversion tools. Regexp for emphasized text was changes in the proper way, now it works very close to that in Emacs Org Mode.
