### PR TITLE
Parser reviewed; some bugs fixed. 

### DIFF
--- a/lib/org-ruby/headline.rb
+++ b/lib/org-ruby/headline.rb
@@ -45,7 +45,6 @@ module Orgmode
     def initialize(line, parser = nil, offset=0)
       super(line, parser)
       @body_lines = []
-      @body_lines << self       # Make @body_lines contain the headline?
       @tags = []
       @export_state = :exclude
       if (@line =~ LineRegexp) then

--- a/lib/org-ruby/html_output_buffer.rb
+++ b/lib/org-ruby/html_output_buffer.rb
@@ -24,7 +24,7 @@ module Orgmode
       :table => "table",
       :table_row => "tr",
       :table_header => "tr",
-      :blockquote => "blockquote",
+      :quote => "blockquote",
       :example => "pre",
       :src => "pre",
       :inline_example => "pre",

--- a/lib/org-ruby/html_output_buffer.rb
+++ b/lib/org-ruby/html_output_buffer.rb
@@ -23,7 +23,6 @@ module Orgmode
       :definition_descr => "dd",
       :table => "table",
       :table_row => "tr",
-      :table_header => "tr",
       :quote => "blockquote",
       :example => "pre",
       :src => "pre",

--- a/lib/org-ruby/html_output_buffer.rb
+++ b/lib/org-ruby/html_output_buffer.rb
@@ -13,11 +13,6 @@ module Orgmode
 
   class HtmlOutputBuffer < OutputBuffer
 
-    # The amount of whitespaces to be stripped at the beginning of
-    # each line in code block. Each array's element corresponds to a
-    # code block.
-    attr_accessor :code_indent_stack
-
     HtmlBlockTag = {
       :paragraph => "p",
       :ordered_list => "ol",
@@ -326,9 +321,9 @@ module Orgmode
     end
 
     def strip_code_block!
-      code_indent = @code_indent_stack.shift
-      strip_regexp = Regexp.new('\n' + ' ' * code_indent)
+      strip_regexp = Regexp.new('\n' + ' ' * @code_block_indent)
       @buffer.gsub!(strip_regexp, "\n")
+      @code_block_indent = nil
     end
   end                           # class HtmlOutputBuffer
 end                             # module Orgmode

--- a/lib/org-ruby/html_output_buffer.rb
+++ b/lib/org-ruby/html_output_buffer.rb
@@ -149,22 +149,8 @@ module Orgmode
         @new_paragraph = nil
         @logger.debug "FLUSH      ==========> #{current_mode}"
 
-        case
-        when @buffered_lines[0].kind_of?(Headline)
-          headline = @buffered_lines[0]
-          raise "Cannot be more than one headline!" if @buffered_lines.length > 1
-          if @options[:export_heading_number] then
-            level = headline.level
-            heading_number = get_next_headline_number(level)
-            @output << "<span class=\"heading-number heading-number-#{level}\">#{heading_number} </span>"
-          end
-          if @options[:export_todo] and headline.keyword then
-            keyword = headline.keyword
-            @output << "<span class=\"todo-keyword #{keyword}\">#{keyword} </span>"
-          end
-          @output << inline_formatting(@buffer)
-
-        when current_mode == :definition_term
+        case current_mode
+        when :definition_term
           d = @buffer.split("::", 2)
           @output << inline_formatting(d[0].strip)
           indent = @list_indent_stack.last
@@ -175,7 +161,7 @@ module Orgmode
           @output << inline_formatting(d[1].strip)
           @new_paragraph = nil
 
-        when current_mode == :horizontal_rule
+        when :horizontal_rule
           add_paragraph unless @new_paragraph == :start
           @new_paragraph = true
           @output << "<hr />"
@@ -184,7 +170,19 @@ module Orgmode
           @output << inline_formatting(@buffer)
         end
       end
-      clear_accumulation_buffer!
+      @buffer = ""
+    end
+
+    def add_line_attributes headline
+      if @options[:export_heading_number] then
+        level = headline.level
+        heading_number = get_next_headline_number(level)
+        @output << "<span class=\"heading-number heading-number-#{level}\">#{heading_number} </span>"
+      end
+      if @options[:export_todo] and headline.keyword then
+        keyword = headline.keyword
+        @output << "<span class=\"todo-keyword #{keyword}\">#{keyword} </span>"
+      end
     end
 
     def output_footnotes!

--- a/lib/org-ruby/html_output_buffer.rb
+++ b/lib/org-ruby/html_output_buffer.rb
@@ -110,7 +110,7 @@ module Orgmode
     def flush!
       case
       when preserve_whitespace?
-        strip_code_block if mode_is_code? current_mode
+        strip_code_block! if mode_is_code? current_mode
 
         # NOTE: CodeRay and Pygments already escape the html once, so
         # no need to escape_buffer!
@@ -325,7 +325,7 @@ module Orgmode
       $VERBOSE = warn_level
     end
 
-    def strip_code_block
+    def strip_code_block!
       code_indent = @code_indent_stack.shift
       strip_regexp = Regexp.new('\n' + ' ' * code_indent)
       @buffer.gsub!(strip_regexp, "\n")

--- a/lib/org-ruby/line.rb
+++ b/lib/org-ruby/line.rb
@@ -229,14 +229,14 @@ module Orgmode
         :property_drawer_item
       when metadata?
         :metadata
-      when (block_type and block_type.casecmp("QUOTE") == 0)
-        :blockquote
-      when (block_type and block_type.casecmp("CENTER") == 0)
-        :center
-      when (block_type and block_type.casecmp("EXAMPLE") == 0)
-        :example
-      when (block_type and block_type.casecmp("SRC") == 0)
-        :src
+      when block_type
+        case block_type.upcase
+        when "QUOTE"   then :quote
+        when "CENTER"  then :center
+        when "EXAMPLE" then :example
+        when "SRC"     then :src
+        when "COMMENT" then :comment
+        end
       when comment?
         :comment
       when table_separator?

--- a/lib/org-ruby/output_buffer.rb
+++ b/lib/org-ruby/output_buffer.rb
@@ -77,7 +77,7 @@ module Orgmode
         @buffer << "\n" << line.output_text
       else
         case line.paragraph_type
-        when :metadata, :table_separator, :blank, :comment, :property_drawer_item, :property_drawer_begin_block, :property_drawer_end_block, :blockquote, :center, :example, :src
+        when :metadata, :table_separator, :blank, :comment, :property_drawer_item, :property_drawer_begin_block, :property_drawer_end_block, :quote, :center, :example, :src
           # Nothing
         else
           @buffer << "\n"
@@ -131,7 +131,7 @@ module Orgmode
     end
 
     def mode_is_block?(mode)
-      [:blockquote, :center, :example, :src].include? mode
+      [:quote, :center, :example, :src].include? mode
     end
 
     def mode_is_code?(mode)

--- a/lib/org-ruby/output_buffer.rb
+++ b/lib/org-ruby/output_buffer.rb
@@ -22,10 +22,6 @@ module Orgmode
       # without intervening newlines.
       @buffer = ""
 
-      # These are the Line objects that are currently in the
-      # accumulation buffer.
-      @buffered_lines = []
-
       # This stack is used to do proper outline numbering of
       # headlines.
       @headline_number_stack = []
@@ -69,10 +65,10 @@ module Orgmode
         flush!
         maintain_mode_stack(line)
       end
+      add_line_attributes(line) if line.kind_of? Headline
       @output_type = line.assigned_paragraph_type || line.paragraph_type
 
       # Adds the current line to the output buffer
-      @buffered_lines.push(line)
       if preserve_whitespace? and not line.begin_block?
         @buffer << "\n" << line.output_text
       else
@@ -85,15 +81,6 @@ module Orgmode
           @buffer << line.output_text.strip
         end
       end
-    end
-
-    # Flushes everything currently in the accumulation buffer into the
-    # output buffer. Derived classes must override this to actually move
-    # content into the output buffer with the appropriate markup. This
-    # method just does common bookkeeping cleanup.
-    def clear_accumulation_buffer!
-      @buffer = ""
-      @buffered_lines = []
     end
 
     # Gets the next headline number for a given level. The intent is

--- a/lib/org-ruby/parser.rb
+++ b/lib/org-ruby/parser.rb
@@ -168,9 +168,9 @@ module Orgmode
       output = ""
       output_buffer = TextileOutputBuffer.new(output)
 
-      Parser.translate(@header_lines, output_buffer)
+      translate(@header_lines, output_buffer)
       @headlines.each do |headline|
-        Parser.translate(headline.body_lines, output_buffer)
+        translate(headline.body_lines, output_buffer)
       end
       output
     end
@@ -195,9 +195,9 @@ module Orgmode
         # If we're given a new title, then just create a new line
         # for that title.
         title = Line.new(@in_buffer_settings["TITLE"], self)
-        Parser.translate([title], output_buffer)
+        translate([title], output_buffer)
       end
-      Parser.translate(@header_lines, output_buffer) unless skip_header_lines?
+      translate(@header_lines, output_buffer) unless skip_header_lines?
 
       # If we've output anything at all, remove the :decorate_title option.
       export_options.delete(:decorate_title) if (output.length > 0)
@@ -207,9 +207,9 @@ module Orgmode
         when :exclude
           # NOTHING
         when :headline_only
-          Parser.translate(headline.body_lines[0, 1], output_buffer)
+          translate(headline.body_lines[0, 1], output_buffer)
         when :all
-          Parser.translate(headline.body_lines, output_buffer)
+          translate(headline.body_lines, output_buffer)
         end
       end
       output << "\n"
@@ -223,7 +223,7 @@ module Orgmode
 
     # Converts an array of lines to the appropriate format.
     # Writes the output to +output_buffer+.
-    def self.translate(lines, output_buffer)
+    def translate(lines, output_buffer)
       output_buffer.output_type = :start
       lines.each { |line| output_buffer.insert(line) }
       output_buffer.flush!

--- a/lib/org-ruby/parser.rb
+++ b/lib/org-ruby/parser.rb
@@ -96,8 +96,6 @@ module Orgmode
       @header_lines = []
       @in_buffer_settings = { }
       @options = { }
-      @code_indent_stack = []
-      @code_indent = nil
       mode = :normal
       previous_line = nil
       table_header_set = false
@@ -118,17 +116,7 @@ module Orgmode
           end
           table_header_set = false if !line.table?
 
-          if @code_indent
-            @code_indent_stack.push @code_indent
-            @code_indent = nil
-          end
         when :example, :src
-          if @code_indent
-            @code_indent = [@code_indent, line.indent].min
-          else
-            @code_indent = line.indent
-          end
-
           # As long as we stay in code mode, force lines to be paragraphs.
           # Don't try to interpret structural items, like headings and tables.
           line.assigned_paragraph_type = :paragraph
@@ -188,7 +176,6 @@ module Orgmode
       export_options[:skip_tables] = true if not export_tables?
       output = ""
       output_buffer = HtmlOutputBuffer.new(output, export_options)
-      output_buffer.code_indent_stack = @code_indent_stack
 
       if @in_buffer_settings["TITLE"] then
 

--- a/lib/org-ruby/parser.rb
+++ b/lib/org-ruby/parser.rb
@@ -138,7 +138,7 @@ module Orgmode
           @headlines << @current_headline = line if Headline.headline? line.line
           # If there is a setting on this line, remember it.
           line.in_buffer_setting? do |key, value|
-            store_in_buffer_setting key, value
+            store_in_buffer_setting key.upcase, value
           end
 
           mode = line.paragraph_type if line.begin_block?
@@ -179,7 +179,7 @@ module Orgmode
     def to_html
       mark_trees_for_export
       export_options = {
-        :decorate_title => true,
+        :decorate_title => @in_buffer_settings["TITLE"],
         :export_heading_number => export_heading_number?,
         :export_todo => export_todo?,
         :use_sub_superscripts =>  use_sub_superscripts?,

--- a/lib/org-ruby/textile_output_buffer.rb
+++ b/lib/org-ruby/textile_output_buffer.rb
@@ -15,7 +15,7 @@ module Orgmode
       @list_indent_stack.push(indent)
       super(mode)
       @output << "bc. " if mode_is_code? mode
-      if mode == :center or mode == :blockquote
+      if mode == :center or mode == :quote
         @add_paragraph = false
         @output << "\n"
       end
@@ -24,7 +24,7 @@ module Orgmode
     def pop_mode(mode = nil)
       m = super(mode)
       @list_indent_stack.pop
-      if m == :center or m == :blockquote
+      if m == :center or m == :quote
         @add_paragraph = true
         @output << "\n"
       end
@@ -98,7 +98,7 @@ module Orgmode
         when current_mode == :paragraph
           @output << "p. " if @add_paragraph
           @output << "p=. " if @mode_stack[0] == :center
-          @output << "bq. " if @mode_stack[0] == :blockquote
+          @output << "bq. " if @mode_stack[0] == :quote
 
         when current_mode == :list_item
           if @mode_stack[-2] == :ordered_list

--- a/lib/org-ruby/textile_output_buffer.rb
+++ b/lib/org-ruby/textile_output_buffer.rb
@@ -89,36 +89,35 @@ module Orgmode
         @output << @buffer << "\n"
 
       when @buffer.length > 0
-        case
-        when @buffered_lines[0].kind_of?(Headline)
-          headline = @buffered_lines[0]
-          raise "Cannot be more than one headline!" if @buffered_lines.length > 1
-          @output << "h#{headline.level}. "
-
-        when current_mode == :paragraph
+        case current_mode
+        when :paragraph
           @output << "p. " if @add_paragraph
           @output << "p=. " if @mode_stack[0] == :center
           @output << "bq. " if @mode_stack[0] == :quote
 
-        when current_mode == :list_item
+        when :list_item
           if @mode_stack[-2] == :ordered_list
             @output << "#" * @mode_stack.count(:list_item) << " "
           else # corresponds to unordered list
             @output << "*" * @mode_stack.count(:list_item) << " "
           end
 
-        when (current_mode == :definition_term and @support_definition_list)
-          @output << "-" * @mode_stack.count(:definition_term) << " "
-          @buffer.sub!("::", ":=")
+        when :definition_term
+          if @support_definition_list
+            @output << "-" * @mode_stack.count(:definition_term) << " "
+            @buffer.sub!("::", ":=")
+          end
         end
         @output << inline_formatting(@buffer) << "\n"
 
       when @output_type == :blank
         @output << "\n"
       end
-      clear_accumulation_buffer!
+      @buffer = ""
     end
 
-
+    def add_line_attributes headline
+      @output << "h#{headline.level}. "
+    end
   end                           # class TextileOutputBuffer
 end                             # module Orgmode

--- a/spec/html_code_syntax_highlight_examples/advanced-code-coderay.html
+++ b/spec/html_code_syntax_highlight_examples/advanced-code-coderay.html
@@ -17,23 +17,23 @@
 <h1><span class="heading-number heading-number-1">2 </span>BEGIN_SRC</h1>
 <p>And this:</p>
 <pre class="src src-ruby">
-    <span style="color:#777"># Finds all emphasis matches in a string.</span>
-    <span style="color:#777"># Supply a block that will get the marker and body as parameters.</span>
-    <span style="color:#080;font-weight:bold">def</span> <span style="color:#06B;font-weight:bold">match_all</span>(str)
-      str.scan(<span style="color:#33B">@org_emphasis_regexp</span>) <span style="color:#080;font-weight:bold">do</span> |match|
-        <span style="color:#080;font-weight:bold">yield</span> <span style="color:#d70">$2</span>, <span style="color:#d70">$3</span>
-      <span style="color:#080;font-weight:bold">end</span>
-    <span style="color:#080;font-weight:bold">end</span>
+<span style="color:#777"># Finds all emphasis matches in a string.</span>
+<span style="color:#777"># Supply a block that will get the marker and body as parameters.</span>
+<span style="color:#080;font-weight:bold">def</span> <span style="color:#06B;font-weight:bold">match_all</span>(str)
+  str.scan(<span style="color:#33B">@org_emphasis_regexp</span>) <span style="color:#080;font-weight:bold">do</span> |match|
+    <span style="color:#080;font-weight:bold">yield</span> <span style="color:#d70">$2</span>, <span style="color:#d70">$3</span>
+  <span style="color:#080;font-weight:bold">end</span>
+<span style="color:#080;font-weight:bold">end</span>
 </pre>
 <p>Now let&#8217;s test case-insensitive code blocks.</p>
 <pre class="src src-ruby">
-    <span style="color:#777"># Finds all emphasis matches in a string.</span>
-    <span style="color:#777"># Supply a block that will get the marker and body as parameters.</span>
-    <span style="color:#080;font-weight:bold">def</span> <span style="color:#06B;font-weight:bold">match_all</span>(str)
-      str.scan(<span style="color:#33B">@org_emphasis_regexp</span>) <span style="color:#080;font-weight:bold">do</span> |match|
-        <span style="color:#080;font-weight:bold">yield</span> <span style="color:#d70">$2</span>, <span style="color:#d70">$3</span>
-      <span style="color:#080;font-weight:bold">end</span>
-    <span style="color:#080;font-weight:bold">end</span>
+<span style="color:#777"># Finds all emphasis matches in a string.</span>
+<span style="color:#777"># Supply a block that will get the marker and body as parameters.</span>
+<span style="color:#080;font-weight:bold">def</span> <span style="color:#06B;font-weight:bold">match_all</span>(str)
+  str.scan(<span style="color:#33B">@org_emphasis_regexp</span>) <span style="color:#080;font-weight:bold">do</span> |match|
+    <span style="color:#080;font-weight:bold">yield</span> <span style="color:#d70">$2</span>, <span style="color:#d70">$3</span>
+  <span style="color:#080;font-weight:bold">end</span>
+<span style="color:#080;font-weight:bold">end</span>
 </pre>
 <pre class="src src-clojure">
 (<span style="color:#080;font-weight:bold">def</span> <span style="color:#06B;font-weight:bold">fib-seq</span>
@@ -76,12 +76,12 @@ Nothing to see here
 </pre>
 <h2><span class="heading-number heading-number-2">4.2 </span>CSS example</h2>
 <pre class="src src-css">
- <span style="color:#339;font-weight:bold">*</span> {
-  <span style="color:#777">/* apply a natural box layout model to all elements */</span>
-  <span style="color:#606">box-sizing</span>: <span style="color:#088">border-box</span>; 
-  <span style="color:#606">-moz-box-sizing</span>: <span style="color:#088">border-box</span>; 
-  <span style="color:#606">-webkit-box-sizing</span>: <span style="color:#088">border-box</span>; 
- }
+<span style="color:#339;font-weight:bold">*</span> {
+ <span style="color:#777">/* apply a natural box layout model to all elements */</span>
+ <span style="color:#606">box-sizing</span>: <span style="color:#088">border-box</span>; 
+ <span style="color:#606">-moz-box-sizing</span>: <span style="color:#088">border-box</span>; 
+ <span style="color:#606">-webkit-box-sizing</span>: <span style="color:#088">border-box</span>; 
+}
 </pre>
 <h2><span class="heading-number heading-number-2">4.3 </span>HTML example</h2>
 <pre class="src src-html">

--- a/spec/html_code_syntax_highlight_examples/advanced-code-no-color.html
+++ b/spec/html_code_syntax_highlight_examples/advanced-code-no-color.html
@@ -17,23 +17,23 @@
 <h1><span class="heading-number heading-number-1">2 </span>BEGIN_SRC</h1>
 <p>And this:</p>
 <pre class="src src-ruby">
-    # Finds all emphasis matches in a string.
-    # Supply a block that will get the marker and body as parameters.
-    def match_all(str)
-      str.scan(@org_emphasis_regexp) do |match|
-        yield $2, $3
-      end
-    end
+# Finds all emphasis matches in a string.
+# Supply a block that will get the marker and body as parameters.
+def match_all(str)
+  str.scan(@org_emphasis_regexp) do |match|
+    yield $2, $3
+  end
+end
 </pre>
 <p>Now let&#8217;s test case-insensitive code blocks.</p>
 <pre class="src src-ruby">
-    # Finds all emphasis matches in a string.
-    # Supply a block that will get the marker and body as parameters.
-    def match_all(str)
-      str.scan(@org_emphasis_regexp) do |match|
-        yield $2, $3
-      end
-    end
+# Finds all emphasis matches in a string.
+# Supply a block that will get the marker and body as parameters.
+def match_all(str)
+  str.scan(@org_emphasis_regexp) do |match|
+    yield $2, $3
+  end
+end
 </pre>
 <pre class="src src-clojure">
 (def fib-seq

--- a/spec/html_code_syntax_highlight_examples/advanced-code-pygments.html
+++ b/spec/html_code_syntax_highlight_examples/advanced-code-pygments.html
@@ -16,22 +16,22 @@
 <p>Two ASCII blobs.</p>
 <h1><span class="heading-number heading-number-1">2 </span>BEGIN_SRC</h1>
 <p>And this:</p>
-<div class="highlight"><pre>    <span class="c1"># Finds all emphasis matches in a string.</span>
-    <span class="c1"># Supply a block that will get the marker and body as parameters.</span>
-    <span class="k">def</span> <span class="nf">match_all</span><span class="p">(</span><span class="n">str</span><span class="p">)</span>
-      <span class="n">str</span><span class="o">.</span><span class="n">scan</span><span class="p">(</span><span class="vi">@org_emphasis_regexp</span><span class="p">)</span> <span class="k">do</span> <span class="o">|</span><span class="n">match</span><span class="o">|</span>
-        <span class="k">yield</span> <span class="vg">$2</span><span class="p">,</span> <span class="vg">$3</span>
-      <span class="k">end</span>
-    <span class="k">end</span>
+<div class="highlight"><pre><span class="c1"># Finds all emphasis matches in a string.</span>
+<span class="c1"># Supply a block that will get the marker and body as parameters.</span>
+<span class="k">def</span> <span class="nf">match_all</span><span class="p">(</span><span class="n">str</span><span class="p">)</span>
+  <span class="n">str</span><span class="o">.</span><span class="n">scan</span><span class="p">(</span><span class="vi">@org_emphasis_regexp</span><span class="p">)</span> <span class="k">do</span> <span class="o">|</span><span class="n">match</span><span class="o">|</span>
+    <span class="k">yield</span> <span class="vg">$2</span><span class="p">,</span> <span class="vg">$3</span>
+  <span class="k">end</span>
+<span class="k">end</span>
 </pre></div>
 <p>Now let&#8217;s test case-insensitive code blocks.</p>
-<div class="highlight"><pre>    <span class="c1"># Finds all emphasis matches in a string.</span>
-    <span class="c1"># Supply a block that will get the marker and body as parameters.</span>
-    <span class="k">def</span> <span class="nf">match_all</span><span class="p">(</span><span class="n">str</span><span class="p">)</span>
-      <span class="n">str</span><span class="o">.</span><span class="n">scan</span><span class="p">(</span><span class="vi">@org_emphasis_regexp</span><span class="p">)</span> <span class="k">do</span> <span class="o">|</span><span class="n">match</span><span class="o">|</span>
-        <span class="k">yield</span> <span class="vg">$2</span><span class="p">,</span> <span class="vg">$3</span>
-      <span class="k">end</span>
-    <span class="k">end</span>
+<div class="highlight"><pre><span class="c1"># Finds all emphasis matches in a string.</span>
+<span class="c1"># Supply a block that will get the marker and body as parameters.</span>
+<span class="k">def</span> <span class="nf">match_all</span><span class="p">(</span><span class="n">str</span><span class="p">)</span>
+  <span class="n">str</span><span class="o">.</span><span class="n">scan</span><span class="p">(</span><span class="vi">@org_emphasis_regexp</span><span class="p">)</span> <span class="k">do</span> <span class="o">|</span><span class="n">match</span><span class="o">|</span>
+    <span class="k">yield</span> <span class="vg">$2</span><span class="p">,</span> <span class="vg">$3</span>
+  <span class="k">end</span>
+<span class="k">end</span>
 </pre></div>
 <div class="highlight"><pre><span class="p">(</span><span class="k">def </span><span class="nv">fib-seq</span>
   <span class="p">(</span><span class="nf">concat</span>
@@ -68,12 +68,12 @@
 <div class="highlight"><pre>&lt;script&gt;alert(&#39;hello world&#39;)&lt;/script&gt;
 </pre></div>
 <h2><span class="heading-number heading-number-2">4.2 </span>CSS example</h2>
-<div class="highlight"><pre> <span class="o">*</span> <span class="p">{</span>
-  <span class="c">/* apply a natural box layout model to all elements */</span>
-  <span class="n">box</span><span class="o">-</span><span class="n">sizing</span><span class="o">:</span> <span class="k">border</span><span class="o">-</span><span class="n">box</span><span class="p">;</span> 
-  <span class="o">-</span><span class="n">moz</span><span class="o">-</span><span class="n">box</span><span class="o">-</span><span class="n">sizing</span><span class="o">:</span> <span class="k">border</span><span class="o">-</span><span class="n">box</span><span class="p">;</span> 
-  <span class="o">-</span><span class="n">webkit</span><span class="o">-</span><span class="n">box</span><span class="o">-</span><span class="n">sizing</span><span class="o">:</span> <span class="k">border</span><span class="o">-</span><span class="n">box</span><span class="p">;</span> 
- <span class="p">}</span>
+<div class="highlight"><pre><span class="o">*</span> <span class="p">{</span>
+ <span class="c">/* apply a natural box layout model to all elements */</span>
+ <span class="n">box</span><span class="o">-</span><span class="n">sizing</span><span class="o">:</span> <span class="k">border</span><span class="o">-</span><span class="n">box</span><span class="p">;</span> 
+ <span class="o">-</span><span class="n">moz</span><span class="o">-</span><span class="n">box</span><span class="o">-</span><span class="n">sizing</span><span class="o">:</span> <span class="k">border</span><span class="o">-</span><span class="n">box</span><span class="p">;</span> 
+ <span class="o">-</span><span class="n">webkit</span><span class="o">-</span><span class="n">box</span><span class="o">-</span><span class="n">sizing</span><span class="o">:</span> <span class="k">border</span><span class="o">-</span><span class="n">box</span><span class="p">;</span> 
+<span class="p">}</span>
 </pre></div>
 <h2><span class="heading-number heading-number-2">4.3 </span>HTML example</h2>
 <div class="highlight"><pre><span class="nt">&lt;html&gt;</span>

--- a/spec/html_code_syntax_highlight_examples/code-coderay.html
+++ b/spec/html_code_syntax_highlight_examples/code-coderay.html
@@ -1,4 +1,4 @@
-<h1 class="title">Simple Code Syntax highlighting test</h1>
+<h1>Simple Code Syntax highlighting test</h1>
 <pre class="src src-ruby">
 <span style="color:#080;font-weight:bold">class</span> <span style="color:#B06;font-weight:bold">Coderay</span>
   <span style="color:#080;font-weight:bold">class</span> &lt;&lt; <span style="color:#B06;font-weight:bold">self</span>

--- a/spec/html_code_syntax_highlight_examples/code-no-color.html
+++ b/spec/html_code_syntax_highlight_examples/code-no-color.html
@@ -1,4 +1,4 @@
-<h1 class="title">Simple Code Syntax highlighting test</h1>
+<h1>Simple Code Syntax highlighting test</h1>
 <pre class="src src-ruby">
 class Pygments
   class &lt;&lt; self

--- a/spec/html_code_syntax_highlight_examples/code-pygments.html
+++ b/spec/html_code_syntax_highlight_examples/code-pygments.html
@@ -1,4 +1,4 @@
-<h1 class="title">Simple Code Syntax highlighting test</h1>
+<h1>Simple Code Syntax highlighting test</h1>
 <div class="highlight"><pre><span class="k">class</span> <span class="nc">Pygments</span>
   <span class="k">class</span> <span class="o">&lt;&lt;</span> <span class="nb">self</span>
     <span class="k">def</span> <span class="nf">colorize</span>

--- a/spec/html_code_syntax_highlight_examples/src-code-list-coderay.html
+++ b/spec/html_code_syntax_highlight_examples/src-code-list-coderay.html
@@ -2,22 +2,22 @@
 <ul>
   <li>Foo
     <pre class="src src-ruby">
-    <span style="color:#080;font-weight:bold">class</span> <span style="color:#B06;font-weight:bold">Hello</span>
-      <span style="color:#080;font-weight:bold">def</span> <span style="color:#06B;font-weight:bold">say</span>
-        puts <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">'</span><span style="color:#D20">cheers</span><span style="color:#710">'</span></span>
-      <span style="color:#080;font-weight:bold">end</span>
-    <span style="color:#080;font-weight:bold">end</span>
+<span style="color:#080;font-weight:bold">class</span> <span style="color:#B06;font-weight:bold">Hello</span>
+  <span style="color:#080;font-weight:bold">def</span> <span style="color:#06B;font-weight:bold">say</span>
+    puts <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">'</span><span style="color:#D20">cheers</span><span style="color:#710">'</span></span>
+  <span style="color:#080;font-weight:bold">end</span>
+<span style="color:#080;font-weight:bold">end</span>
     </pre>
   </li>
   <li>Bar
     <pre class="src src-ruby">
-    puts <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">&quot;</span><span style="color:#D20">This should not get lumped into the above line Example</span><span style="color:#710">&quot;</span></span>
+puts <span style="background-color:hsla(0,100%,50%,0.05)"><span style="color:#710">&quot;</span><span style="color:#D20">This should not get lumped into the above line Example</span><span style="color:#710">&quot;</span></span>
     </pre>
     <p>A paragraph should go here.</p>
     <ul>
       <li>A sublist goes here with another example
         <pre class="src src-sh">
-      echo &quot;Hello&quot;
+echo &quot;Hello&quot;
         </pre>
         <p>And this is a paragraph</p>
       </li>

--- a/spec/html_code_syntax_highlight_examples/src-code-list-coderay.html
+++ b/spec/html_code_syntax_highlight_examples/src-code-list-coderay.html
@@ -1,4 +1,4 @@
-<h1 class="title">begin src in lists should work</h1>
+<h1>begin src in lists should work</h1>
 <ul>
   <li>Foo
     <pre class="src src-ruby">

--- a/spec/html_code_syntax_highlight_examples/src-code-list-no-color.html
+++ b/spec/html_code_syntax_highlight_examples/src-code-list-no-color.html
@@ -1,4 +1,4 @@
-<h1 class="title">begin src in lists should work</h1>
+<h1>begin src in lists should work</h1>
 <ul>
   <li>Foo
     <pre class="src src-ruby">

--- a/spec/html_code_syntax_highlight_examples/src-code-list-no-color.html
+++ b/spec/html_code_syntax_highlight_examples/src-code-list-no-color.html
@@ -2,22 +2,22 @@
 <ul>
   <li>Foo
     <pre class="src src-ruby">
-    class Hello
-      def say
-        puts 'cheers'
-      end
-    end
+class Hello
+  def say
+    puts 'cheers'
+  end
+end
     </pre>
   </li>
   <li>Bar
     <pre class="src src-ruby">
-    puts "This should not get lumped into the above line Example"
+puts "This should not get lumped into the above line Example"
     </pre>
     <p>A paragraph should go here.</p>
     <ul>
       <li>A sublist goes here with another example
         <pre class="src src-sh">
-      echo "Hello"
+echo "Hello"
         </pre>
         <p>And this is a paragraph</p>
       </li>

--- a/spec/html_code_syntax_highlight_examples/src-code-list-pygments.html
+++ b/spec/html_code_syntax_highlight_examples/src-code-list-pygments.html
@@ -1,4 +1,4 @@
-<h1 class="title">begin src in lists should work</h1>
+<h1>begin src in lists should work</h1>
 <ul>
   <li>Foo
 <div class="highlight"><pre><span class="k">class</span> <span class="nc">Hello</span>

--- a/spec/html_code_syntax_highlight_examples/src-code-list-pygments.html
+++ b/spec/html_code_syntax_highlight_examples/src-code-list-pygments.html
@@ -1,19 +1,19 @@
 <h1 class="title">begin src in lists should work</h1>
 <ul>
   <li>Foo
-<div class="highlight"><pre>    <span class="k">class</span> <span class="nc">Hello</span>
-      <span class="k">def</span> <span class="nf">say</span>
-        <span class="nb">puts</span> <span class="s1">&#39;cheers&#39;</span>
-      <span class="k">end</span>
-    <span class="k">end</span>
+<div class="highlight"><pre><span class="k">class</span> <span class="nc">Hello</span>
+  <span class="k">def</span> <span class="nf">say</span>
+    <span class="nb">puts</span> <span class="s1">&#39;cheers&#39;</span>
+  <span class="k">end</span>
+<span class="k">end</span>
 </pre></div></li>
   <li>Bar
-<div class="highlight"><pre>    <span class="nb">puts</span> <span class="s2">&quot;This should not get lumped into the above line Example&quot;</span>
+<div class="highlight"><pre><span class="nb">puts</span> <span class="s2">&quot;This should not get lumped into the above line Example&quot;</span>
 </pre></div>
     <p>A paragraph should go here.</p>
     <ul>
       <li>A sublist goes here with another example
-<div class="highlight"><pre>      <span class="nb">echo</span> <span class="s2">&quot;Hello&quot;</span>
+<div class="highlight"><pre><span class="nb">echo</span> <span class="s2">&quot;Hello&quot;</span>
 </pre></div>
         <p>And this is a paragraph</p>
       </li>

--- a/spec/html_examples/advanced-lists.html
+++ b/spec/html_examples/advanced-lists.html
@@ -1,4 +1,4 @@
-<p class="title">Advanced Lists</p>
+<p>Advanced Lists</p>
 <p><code>org-ruby</code> supports the following list features of <code>org-mode</code>:</p>
 <h1>Nested lists</h1>
 <ul>

--- a/spec/html_examples/block_code.html
+++ b/spec/html_examples/block_code.html
@@ -1,4 +1,4 @@
-<h1 class="title">Block Code</h1>
+<h1>Block Code</h1>
 <p>I need to get block code examples working. In <code>orgmode</code>, they look
   like this:</p>
 <pre class="example">

--- a/spec/html_examples/blockcomment.html
+++ b/spec/html_examples/blockcomment.html
@@ -1,3 +1,3 @@
-<p class="title">BLOCKCOMMENT</p>
+<p>BLOCKCOMMENT</p>
 <p>Testing that the next part is ignored</p>
 <p>And now back to normal!</p>

--- a/spec/html_examples/blockquote.html
+++ b/spec/html_examples/blockquote.html
@@ -1,4 +1,4 @@
-<p class="title">BLOCKQUOTE</p>
+<p>BLOCKQUOTE</p>
 <p>Testing that I can have block quotes:</p>
 <blockquote>
   <p><i>Example:</i></p>

--- a/spec/html_examples/code-block-lists.html
+++ b/spec/html_examples/code-block-lists.html
@@ -40,7 +40,7 @@ puts "test"
     <ul>
       <li>Block without indentation
         <pre class="example">
-  puts "test"
+puts "test"
         </pre>
       </li>
     </ul>
@@ -62,7 +62,7 @@ puts "test"
 <ul>
   <li>Indentation of a begin_example code block
     <pre class="example">
-    (+ 3 5)
+(+ 3 5)
     </pre>
   </li>
 </ul>

--- a/spec/html_examples/code-block-lists.html
+++ b/spec/html_examples/code-block-lists.html
@@ -1,4 +1,4 @@
-<h1 class="title">Code blocks in lists</h1>
+<h1>Code blocks in lists</h1>
 <h2>No spaces in code block</h2>
 <pre class="example">
 - List starts

--- a/spec/html_examples/code-comment.html
+++ b/spec/html_examples/code-comment.html
@@ -1,4 +1,4 @@
-<h1 class="title">Code Comment</h1>
+<h1>Code Comment</h1>
 <p>I need to be able to export things that look like org-mode comments
   inside of code blocks, like this:</p>
 <pre class="example">

--- a/spec/html_examples/code-lists.html
+++ b/spec/html_examples/code-lists.html
@@ -1,4 +1,4 @@
-<h1 class="title">normal list should work</h1>
+<h1>normal list should work</h1>
 <ul>
   <li>one
     text in the same line

--- a/spec/html_examples/code-lists.html
+++ b/spec/html_examples/code-lists.html
@@ -46,16 +46,16 @@
 <ul>
   <li>Foo
     <pre class="example">
-    class Hello
-      def say
-        puts 'cheers'
-      end
-    end
+class Hello
+  def say
+    puts 'cheers'
+  end
+end
     </pre>
   </li>
   <li>Bar
     <pre class="example">
-    This gets lumped in to the above line "Example"
+This gets lumped in to the above line "Example"
     </pre>
   </li>
   <li>Hello</li>

--- a/spec/html_examples/comment-trees.html
+++ b/spec/html_examples/comment-trees.html
@@ -1,4 +1,4 @@
-<h1 class="title">This headline is in the output</h1>
+<h1>This headline is in the output</h1>
 <h1>This is in the output</h1>
 <h2>Yet, this is in the output</h2>
 <p>and this is also part of the output</p>

--- a/spec/html_examples/emphasis.html
+++ b/spec/html_examples/emphasis.html
@@ -1,4 +1,4 @@
-<h1 class="title">Inline Formatting test for emphasis</h1>
+<h1>Inline Formatting test for emphasis</h1>
 <h2>Simple feature test</h2>
 <p><b>bold</b></p>
 <p><i>italic</i></p>

--- a/spec/html_examples/entities.html
+++ b/spec/html_examples/entities.html
@@ -1,4 +1,4 @@
-<p class="title">ENTITIES</p>
+<p>ENTITIES</p>
 <p><code>Org-ruby</code> supports &#8220;smart double quotes,&#8221; &#8216;smart single quotes,&#8217;
   apostrophes for contractions like won&#8217;t and can&#8217;t, and other
   things&#8230; like elipses. Oh &#8211; and dashes.</p>

--- a/spec/html_examples/horizontal_rule.html
+++ b/spec/html_examples/horizontal_rule.html
@@ -1,4 +1,4 @@
-<p class="title">Useful contribution by <a href="http://www.neilsmithline.com">Neil-Smithline</a></p>
+<p>Useful contribution by <a href="http://www.neilsmithline.com">Neil-Smithline</a></p>
 <p>5 hyphens or more,</p>
 <hr />
 <p>will produce a horizontal rule.</p>

--- a/spec/html_examples/html-literal.html
+++ b/spec/html_examples/html-literal.html
@@ -1,4 +1,4 @@
-<p class="title">HTML literals</p>
+<p>HTML literals</p>
 <p>ORG escapes HTML by default. This should &lt;b&gt;not be bold text!&lt;/b&gt;
   Instead, it should look like regular text with some HTML tags around
   it.</p>

--- a/spec/html_examples/inline-formatting.html
+++ b/spec/html_examples/inline-formatting.html
@@ -1,4 +1,4 @@
-<p class="title">Inline Formatting</p>
+<p>Inline Formatting</p>
 <p>I want to make sure I handle all inline formatting. I need to handle
   <b>bold</b>, <i>italic</i>, <code>code</code>, <code>verbatim</code>, <span style="text-decoration:underline;">underline</span>, <del>strikethrough</del>.</p>
 <p>In addition, I need to make sure I can handle links. We&#8217;ve got simple

--- a/spec/html_examples/inline-images.html
+++ b/spec/html_examples/inline-images.html
@@ -1,4 +1,4 @@
-<p class="title">Inline Images</p>
+<p>Inline Images</p>
 <p>Per the org-mode <a href="http://orgmode.org/manual/Images-and-tables.html#Images-and-tables">spec</a>, you can include inline images as links without
   any descriptive link text, like this:</p>
 <p><a href="http://farm5.static.flickr.com/4049/4358074549_5efb8b4903.jpg"><img src="http://farm5.static.flickr.com/4049/4358074549_5efb8b4903.jpg" /></a></p>

--- a/spec/html_examples/lists.html
+++ b/spec/html_examples/lists.html
@@ -1,4 +1,4 @@
-<h1 class="title">Lists</h1>
+<h1>Lists</h1>
 <p>I want to make sure I have great support for lists.</p>
 <ul>
   <li>This is an unordered list</li>

--- a/spec/html_examples/metadata-comment.html
+++ b/spec/html_examples/metadata-comment.html
@@ -1,4 +1,4 @@
-<h1 class="title">Metadata, etc.</h1>
+<h1>Metadata, etc.</h1>
 <p>I normally filter out things that look like metadata. Can&#8217;t do it any
   more. I need to see all of the following:</p>
 <pre class="example">

--- a/spec/html_examples/only-list.html
+++ b/spec/html_examples/only-list.html
@@ -1,4 +1,4 @@
-<ul class="title">
+<ul>
   <li>This file has only a list</li>
   <li>Note it will end with nothing other than a list item.</li>
   <li>the world wants to know: Will org-ruby write the closing ul tag?</li>

--- a/spec/html_examples/only-table.html
+++ b/spec/html_examples/only-table.html
@@ -1,4 +1,4 @@
-<table class="title">
+<table>
   <tr><th>One</th><th>Two</th><th>Three</th><th>Four</th></tr>
   <tr><td>Five</td><td>Six</td><td>Seven</td><td>Eight</td></tr>
   <tr><td>Nine</td><td>Ten</td><td>Eleven</td><td>Twelve</td></tr>

--- a/spec/html_examples/properties_drawer.html
+++ b/spec/html_examples/properties_drawer.html
@@ -1,4 +1,4 @@
-<h1 class="title">The mount point of the fullest disk</h1>
+<h1>The mount point of the fullest disk</h1>
 <h2>query all mounted disks</h2>
 <pre class="example">
 df \

--- a/spec/html_examples/properties_drawer.html
+++ b/spec/html_examples/properties_drawer.html
@@ -1,19 +1,19 @@
 <h1 class="title">The mount point of the fullest disk</h1>
 <h2>query all mounted disks</h2>
 <pre class="example">
-  df \
+df \
 </pre>
 <h2>strip the header row</h2>
 <pre class="example">
-  |sed '1d' \
+|sed '1d' \
 </pre>
 <h2>sort by the percent full</h2>
 <pre class="example">
-  |awk '{print $5 " " $6}'|sort -n |tail -1 \
+|awk '{print $5 " " $6}'|sort -n |tail -1 \
 </pre>
 <h2>extract the mount point</h2>
 <pre class="example">
-  |awk '{print $2}'
+|awk '{print $2}'
 </pre>
 <h1>Properties drawer example</h1>
 <p>These properties are metadata so they should not be visible.</p>

--- a/spec/html_examples/subsupscript-nil.html
+++ b/spec/html_examples/subsupscript-nil.html
@@ -1,3 +1,3 @@
-<p class="title">SUBSUPSCRIPT</p>
+<p>SUBSUPSCRIPT</p>
 <p>a^{b}</p>
 <p>a_{b}</p>

--- a/spec/html_examples/subsupscript.html
+++ b/spec/html_examples/subsupscript.html
@@ -1,3 +1,3 @@
-<p class="title">SUBSUPSCRIPT</p>
+<p>SUBSUPSCRIPT</p>
 <p>a<sup>b</sup></p>
 <p>a<sub>b</sub></p>

--- a/spec/html_examples/tables.html
+++ b/spec/html_examples/tables.html
@@ -1,4 +1,4 @@
-<p class="title">TABLES</p>
+<p>TABLES</p>
 <p>Different types of ORG tables.</p>
 <h1>Simple table, no header.</h1>
 <table>

--- a/spec/html_examples/text.html
+++ b/spec/html_examples/text.html
@@ -1,4 +1,4 @@
-<p class="title">The simplest case: translating plain text.</p>
+<p>The simplest case: translating plain text.</p>
 <p>Lorem ipsum dolor sit amet, consetetur sadipscing elitr, sed diam
   nonumy eirmod tempor invidunt ut labore et dolore magna aliquyam erat,
   sed diam voluptua. At vero eos et accusam et justo duo dolores et ea


### PR DESCRIPTION
Hey!
This code snippet produces the following changes:
- Refactoring of method `initialize` from `parser.rb` was done;
- Headings and tables within a quote or center block are handled properly. It closes issue bdewey/org-ruby#35;
- No need to accumulate `@buffered_lines`, this variable was removed from `output_buffer.rb`;
- Indentation for code blocks was done. It closes issue bdewey/org-ruby#31;
- Adds paragraphs with `class=title` only if the title presents in Org-mode source (line `#+title:some_title`).

Best regards,
Vladimir.
