### PR TITLE
Fix for definition lists.

### DIFF
--- a/lib/org-ruby/html_output_buffer.rb
+++ b/lib/org-ruby/html_output_buffer.rb
@@ -156,14 +156,19 @@ module Orgmode
 
         case current_mode
         when :definition_term
-          d = @buffer.rpartition(/\s+::($|\s+)/)
-          @output << inline_formatting(d[0].strip)
+          d = @buffer.split(/\A(.*[ \t]+|)::(|[ \t]+.*?)$/, 4)
+          d[1] = d[1].strip
+          unless d[1].empty?
+            @output << inline_formatting(d[1])
+          else
+            @output << "???"
+          end
           indent = @list_indent_stack.last
           pop_mode
 
           @new_paragraph = :start
           push_mode(:definition_descr, indent)
-          @output << inline_formatting(d[2])
+          @output << inline_formatting(d[2].strip + d[3])
           @new_paragraph = nil
 
         when :horizontal_rule

--- a/lib/org-ruby/line.rb
+++ b/lib/org-ruby/line.rb
@@ -96,7 +96,7 @@ module Orgmode
       @line.sub(UnorderedListRegexp, "")
     end
 
-    DefinitionListRegexp = /^\s*(-|\+|\s+[*])\s+(.*?)\s+::($|\s+)/
+    DefinitionListRegexp = /^\s*(-|\+|\s+[*])\s+(.*\s+|)::($|\s+)/
 
     def definition_list?
       check_assignment_or_regexp(:definition_list, DefinitionListRegexp)


### PR DESCRIPTION
Hey!
I made a mistake with handling definition lists. It's seen from an example where paragraphs within the definition list have colons `::`, for instance,

```
 + Key :: Value :: Still value (k1)
   Paragraph :: with :: no value
 + Key :: Value :: Still value (k1) ::
   Paragraph :: with :: no value ::
 + ::
   Paragraph :: with :: no value
```

I fixed this mistake and added case with no definition given which in turn is replaced with `???` (the last list). Output:

``` html
<dl>
  <dt>Key :: Value</dt><dd>Still value (k1)
    Paragraph :: with :: no value</dd>
  <dt>Key :: Value :: Still value (k1)</dt><dd>
    Paragraph :: with :: no value ::</dd>
  <dt>???</dt><dd>
    Paragraph :: with :: no value</dd>
</dl>
```

**UPD.** The examples were checked as well.
