### PR TITLE
Characters inside HTML tags <code>...</code> are not escaped.

### DIFF
--- a/lib/org-ruby/html_output_buffer.rb
+++ b/lib/org-ruby/html_output_buffer.rb
@@ -1,3 +1,4 @@
+require 'cgi'
 begin
   require 'pygments'
 rescue LoadError
@@ -110,7 +111,7 @@ module Orgmode
         strip_code_block! if mode_is_code? current_mode
 
         # NOTE: CodeRay and Pygments already escape the html once, so
-        # no need to escape_html! @buffer
+        # no need to escapeHTML
         case
         when (current_mode == :src and defined? Pygments)
           lang = normalize_lang @block_lang
@@ -140,7 +141,7 @@ module Orgmode
           @new_paragraph = true
         else
           # *NOTE* Don't use escape_buffer! through its sensitivity to @<text> forms
-          escape_html! @buffer
+          @buffer = CGI::escapeHTML @buffer
         end
 
         # Whitespace is significant in :code mode. Always output the
@@ -249,13 +250,6 @@ module Orgmode
       @buffer.gsub!(/@(<[^<>\n]*>)/, "\\1")
     end
 
-    # Escapes any HTML content in string beyond @buffer.
-    def escape_html! str
-      str.gsub!(/&/, "&amp;")
-      str.gsub!(/</, "&lt;")
-      str.gsub!(/>/, "&gt;")
-    end
-
     def buffer_indentation
       indent = "  " * @list_indent_stack.length
       @buffer << indent
@@ -280,7 +274,7 @@ module Orgmode
     def inline_formatting(str)
       @re_help.rewrite_emphasis str do |marker, s|
         if marker == "=" or marker == "~"
-          escape_html! s
+          s = CGI::escapeHTML s
           "<#{Tags[marker][:open]}>#{s}</#{Tags[marker][:close]}>"
         else
           "@<#{Tags[marker][:open]}>#{s}@</#{Tags[marker][:close]}>"

--- a/lib/org-ruby/html_output_buffer.rb
+++ b/lib/org-ruby/html_output_buffer.rb
@@ -110,7 +110,7 @@ module Orgmode
         strip_code_block! if mode_is_code? current_mode
 
         # NOTE: CodeRay and Pygments already escape the html once, so
-        # no need to escape_buffer!
+        # no need to escape_html! @buffer
         case
         when (current_mode == :src and defined? Pygments)
           lang = normalize_lang @block_lang
@@ -138,7 +138,8 @@ module Orgmode
           @buffer.gsub!(/\A\n/, "") if @new_paragraph == :start
           @new_paragraph = true
         else
-          escape_buffer!
+          # *NOTE* Don't use escape_buffer! through its sensitivity to @<text> forms
+          escape_html! @buffer
         end
 
         # Whitespace is significant in :code mode. Always output the
@@ -248,7 +249,7 @@ module Orgmode
     end
 
     # Escapes any HTML content in string beyond @buffer.
-    def escape_string! str
+    def escape_html! str
       str.gsub!(/&/, "&amp;")
       str.gsub!(/</, "&lt;")
       str.gsub!(/>/, "&gt;")
@@ -278,7 +279,7 @@ module Orgmode
     def inline_formatting(str)
       @re_help.rewrite_emphasis str do |marker, s|
         if marker == "=" or marker == "~"
-          escape_string! s
+          escape_html! s
           "<#{Tags[marker][:open]}>#{s}</#{Tags[marker][:close]}>"
         else
           "@<#{Tags[marker][:open]}>#{s}@</#{Tags[marker][:close]}>"

--- a/lib/org-ruby/html_output_buffer.rb
+++ b/lib/org-ruby/html_output_buffer.rb
@@ -115,6 +115,7 @@ module Orgmode
         when (current_mode == :src and defined? Pygments)
           lang = normalize_lang @block_lang
           @output << "\n" unless @new_paragraph == :start
+          @new_paragraph = true
 
           begin
             @buffer = Pygments.highlight(@buffer, :lexer => lang)
@@ -360,6 +361,7 @@ module Orgmode
     end
 
     def strip_code_block!
+      @code_block_indent ||= 0
       strip_regexp = Regexp.new("^" + " " * @code_block_indent)
       @buffer.gsub!(strip_regexp, "")
       @code_block_indent = nil

--- a/lib/org-ruby/line.rb
+++ b/lib/org-ruby/line.rb
@@ -3,9 +3,6 @@ module Orgmode
   # Represents a single line of an orgmode file.
   class Line
 
-    # This is the line itself.
-    attr_reader :line
-
     # The indent level of this line. this is important to properly translate
     # nested lists from orgmode to textile.
     # TODO 2009-12-20 bdewey: Handle tabs
@@ -125,7 +122,7 @@ module Orgmode
       return strip_unordered_list_tag if unordered_list?
       return @line.sub(InlineExampleRegexp, "") if inline_example?
       return strip_raw_text_tag if raw_text?
-      return line
+      return @line
     end
 
     def plain_text?

--- a/lib/org-ruby/output_buffer.rb
+++ b/lib/org-ruby/output_buffer.rb
@@ -91,10 +91,12 @@ module Orgmode
       if mode_is_code? current_mode and not line.block_type
         # Determines the amount of whitespaces to be stripped at the
         # beginning of each line in code block.
-        if @code_block_indent
-          @code_block_indent = [@code_block_indent, line.indent].min
-        else
-          @code_block_indent = line.indent
+        if line.paragraph_type != :blank
+          if @code_block_indent
+            @code_block_indent = [@code_block_indent, line.indent].min
+          else
+            @code_block_indent = line.indent
+          end
         end
       end
 

--- a/lib/org-ruby/parser.rb
+++ b/lib/org-ruby/parser.rb
@@ -106,8 +106,8 @@ module Orgmode
 
         case mode
         when :normal, :quote, :center
-          if Headline.headline? line.line
-            line = Headline.new line.line, self, offset
+          if Headline.headline? line.to_s
+            line = Headline.new line.to_s, self, offset
           elsif line.table_separator?
             if previous_line and previous_line.paragraph_type == :table_row and !table_header_set
               previous_line.assigned_paragraph_type = :table_header
@@ -123,7 +123,7 @@ module Orgmode
         end
 
         if mode == :normal
-          @headlines << @current_headline = line if Headline.headline? line.line
+          @headlines << @current_headline = line if Headline.headline? line.to_s
           # If there is a setting on this line, remember it.
           line.in_buffer_setting? do |key, value|
             store_in_buffer_setting key.upcase, value

--- a/lib/org-ruby/regexp_helper.rb
+++ b/lib/org-ruby/regexp_helper.rb
@@ -95,14 +95,18 @@ module Orgmode
       str.gsub!(/%/, "%%")
       format_str = "%s"
       str.gsub! @org_emphasis_regexp do |match|
+        pre = $1
         # preserve the code snippet from further formatting
-        inner = if $2 == "=" or $2 == "~"
-                  @code_snippet_stack.push $3
-                  yield $2, format_str
-                else
-                  yield $2, $3
-                end
-        "#{$1}#{inner}"
+        if $2 == "=" or $2 == "~"
+          inner = yield $2, $3
+          # code is not formatted, so turn to single percent signs
+          inner.gsub!(/%%/, "%")
+          @code_snippet_stack.push inner
+          "#{pre}#{format_str}"
+        else
+          inner = yield $2, $3
+          "#{pre}#{inner}"
+        end
       end
     end
 

--- a/spec/html_code_syntax_highlight_examples/advanced-code-no-color.html
+++ b/spec/html_code_syntax_highlight_examples/advanced-code-no-color.html
@@ -47,7 +47,7 @@ user&gt; (take 20 fib-seq)
 </pre>
 <p>Even if no language is set, it is still wrapped in code tags but class is empty.</p>
 <pre class="src">
-echo 'Defaults env_keeps="http_proxy https_proxy ftp_proxy"' | sudo tee -a /etc/sudoers
+echo 'Defaults env_keeps=&quot;http_proxy https_proxy ftp_proxy&quot;' | sudo tee -a /etc/sudoers
 </pre>
 <h1><span class="heading-number heading-number-1">3</span> It should be possible to write a colon at the beginning of an example</h1>
 <blockquote>
@@ -62,10 +62,10 @@ echo 'Defaults env_keeps="http_proxy https_proxy ftp_proxy"' | sudo tee -a /etc/
 }
 </pre>
 <pre class="src src-clojure">
-(defproject helloworld "0.1"
+(defproject helloworld &quot;0.1&quot;
 :dependencies [[org.clojure/clojure
-                 "1.1.0-master-SNAPSHOT"]
+                 &quot;1.1.0-master-SNAPSHOT&quot;]
               [org.clojure/clojure-contrib
-                 "1.0-SNAPSHOT"]]
+                 &quot;1.0-SNAPSHOT&quot;]]
 :main helloworld)
 </pre>

--- a/spec/html_code_syntax_highlight_examples/code-no-color.html
+++ b/spec/html_code_syntax_highlight_examples/code-no-color.html
@@ -14,14 +14,14 @@ end
 <p>Now using EXAMPLE blocks instead:</p>
 <pre class="example">
 def hello()
-  puts "hello"
+  puts &quot;hello&quot;
 end
 </pre>
 <p>Small case should work as well:</p>
 <pre class="example">
 class Hello
   def say
-    puts "hola"
+    puts &quot;hola&quot;
   end
 end
 </pre>

--- a/spec/html_code_syntax_highlight_examples/code-pygments.html
+++ b/spec/html_code_syntax_highlight_examples/code-pygments.html
@@ -13,14 +13,14 @@
 <p>Now using EXAMPLE blocks instead:</p>
 <pre class="example">
 def hello()
-  puts "hello"
+  puts &quot;hello&quot;
 end
 </pre>
 <p>Small case should work as well:</p>
 <pre class="example">
 class Hello
   def say
-    puts "hola"
+    puts &quot;hola&quot;
   end
 end
 </pre>

--- a/spec/html_code_syntax_highlight_examples/src-code-list-no-color.html
+++ b/spec/html_code_syntax_highlight_examples/src-code-list-no-color.html
@@ -11,13 +11,13 @@ end
   </li>
   <li>Bar
     <pre class="src src-ruby">
-puts "This should not get lumped into the above line Example"
+puts &quot;This should not get lumped into the above line Example&quot;
     </pre>
     <p>A paragraph should go here.</p>
     <ul>
       <li>A sublist goes here with another example
         <pre class="src src-sh">
-echo "Hello"
+echo &quot;Hello&quot;
         </pre>
         <p>And this is a paragraph</p>
       </li>

--- a/spec/html_code_syntax_highlight_examples/src-code-list-pygments.html
+++ b/spec/html_code_syntax_highlight_examples/src-code-list-pygments.html
@@ -6,7 +6,8 @@
     <span class="nb">puts</span> <span class="s1">&#39;cheers&#39;</span>
   <span class="k">end</span>
 <span class="k">end</span>
-</pre></div></li>
+</pre></div>
+  </li>
   <li>Bar
 <div class="highlight"><pre><span class="nb">puts</span> <span class="s2">&quot;This should not get lumped into the above line Example&quot;</span>
 </pre></div>

--- a/spec/html_examples/block_code.html
+++ b/spec/html_examples/block_code.html
@@ -5,7 +5,7 @@
 
 def initialize(output)
   @output = output
-  @buffer = ""
+  @buffer = &quot;&quot;
   @output_type = :start
   @list_indent_stack = []
   @paragraph_modifier = nil

--- a/spec/html_examples/block_code.html
+++ b/spec/html_examples/block_code.html
@@ -3,16 +3,16 @@
   like this:</p>
 <pre class="example">
 
-    def initialize(output)
-      @output = output
-      @buffer = ""
-      @output_type = :start
-      @list_indent_stack = []
-      @paragraph_modifier = nil
+def initialize(output)
+  @output = output
+  @buffer = ""
+  @output_type = :start
+  @list_indent_stack = []
+  @paragraph_modifier = nil
 
-      @logger = Logger.new(STDERR)
-      @logger.level = Logger::WARN
-    end
+  @logger = Logger.new(STDERR)
+  @logger.level = Logger::WARN
+end
 
 </pre>
 <p>And now I should be back to normal text.</p>

--- a/spec/html_examples/code-block-lists.html
+++ b/spec/html_examples/code-block-lists.html
@@ -4,7 +4,7 @@
 - List starts
  + Block without indentation
    #+begin_example
-puts "test"
+puts &quot;test&quot;
    #+end_example
 - List continues here
  + and finished here
@@ -14,7 +14,7 @@ puts "test"
     <ul>
       <li>Block without indentation
         <pre class="example">
-puts "test"
+puts &quot;test&quot;
         </pre>
       </li>
     </ul>
@@ -30,7 +30,7 @@ puts "test"
 - List starts
  + Block without indentation
    #+begin_example ruby
-  puts "test"
+  puts &quot;test&quot;
    #+end_example
 - List continues here
  + and finished here
@@ -40,7 +40,7 @@ puts "test"
     <ul>
       <li>Block without indentation
         <pre class="example">
-puts "test"
+puts &quot;test&quot;
         </pre>
       </li>
     </ul>

--- a/spec/html_examples/code-lists.html
+++ b/spec/html_examples/code-lists.html
@@ -55,7 +55,7 @@ end
   </li>
   <li>Bar
     <pre class="example">
-This gets lumped in to the above line "Example"
+This gets lumped in to the above line &quot;Example&quot;
     </pre>
   </li>
   <li>Hello</li>

--- a/spec/html_examples/emphasis.html
+++ b/spec/html_examples/emphasis.html
@@ -18,23 +18,23 @@
 <h2>Within code test</h2>
 <pre class="example">
 emphasis_tests = [
-"*bold*",
-"/italic/",
-"=code=",
-"~verbatim~",
-"_underline_ ",
-"+strikethrough+",
-"[[http://www.bing.com]]",
-"[[http://www.google.com]]",
-"[[http://www.xkcd.com][helpful text link]]",
-"[[http://farm7.static.flickr.com/6078/6084185195_552aa270b2.jpg]]",
-"[[http://www.xkcd.com][http://imgs.xkcd.com/comics/t_cells.png]]",
-"&lt;http://www.google.com&gt;",
+&quot;*bold*&quot;,
+&quot;/italic/&quot;,
+&quot;=code=&quot;,
+&quot;~verbatim~&quot;,
+&quot;_underline_ &quot;,
+&quot;+strikethrough+&quot;,
+&quot;[[http://www.bing.com]]&quot;,
+&quot;[[http://www.google.com]]&quot;,
+&quot;[[http://www.xkcd.com][helpful text link]]&quot;,
+&quot;[[http://farm7.static.flickr.com/6078/6084185195_552aa270b2.jpg]]&quot;,
+&quot;[[http://www.xkcd.com][http://imgs.xkcd.com/comics/t_cells.png]]&quot;,
+&quot;&lt;http://www.google.com&gt;&quot;,
 ]
 
 all = emphasis_tests.map do |a|
   emphasis_tests.map do |b|
-    [b, ' ', a, ' ', b, "\n\n"].join('')
+    [b, ' ', a, ' ', b, &quot;\n\n&quot;].join('')
   end
 end
 
@@ -42,12 +42,12 @@ all.each {|e| puts e}
 </pre>
 <h2>Mixed together test</h2>
 <pre class="example">
-emphasis_tests = ["*","/","=","~","_","+"]
+emphasis_tests = [&quot;*&quot;,&quot;/&quot;,&quot;=&quot;,&quot;~&quot;,&quot;_&quot;,&quot;+&quot;]
 
 all = emphasis_tests.map do |a|
   emphasis_tests.map do |b|
-    [[a, 'Answer: ', b, '42', b, ' ',a, "\n\n"].join(''),
-     [a, 'Answer: ', b, '42', b, '',a, "\n\n"].join('')].flatten
+    [[a, 'Answer: ', b, '42', b, ' ',a, &quot;\n\n&quot;].join(''),
+     [a, 'Answer: ', b, '42', b, '',a, &quot;\n\n&quot;].join('')].flatten
   end
 end
 
@@ -127,11 +127,11 @@ all.each {|e| puts e}
 <p><del>Answer: +42+</del></p>
 <h2>Multiline support test :: one line</h2>
 <pre class="example">
-emphasis_tests = ["*","/","=","~","_","+"]
+emphasis_tests = [&quot;*&quot;,&quot;/&quot;,&quot;=&quot;,&quot;~&quot;,&quot;_&quot;,&quot;+&quot;]
 
 all = emphasis_tests.map do |a|
   emphasis_tests.map do |b|
-    [a, 'Starting the line here ', "\n", b, 'and continuing here to close', b, a, "\n\n"].join('')
+    [a, 'Starting the line here ', &quot;\n&quot;, b, 'and continuing here to close', b, a, &quot;\n\n&quot;].join('')
   end
 end
 
@@ -211,11 +211,11 @@ all.each {|e| puts e}
   +and continuing here to close+</del></p>
 <h2>Multiline support test :: two lines</h2>
 <pre class="example">
-emphasis_tests = ["*","/","=","~","_","+"]
+emphasis_tests = [&quot;*&quot;,&quot;/&quot;,&quot;=&quot;,&quot;~&quot;,&quot;_&quot;,&quot;+&quot;]
 
 all = emphasis_tests.map do |a|
   emphasis_tests.map do |b|
-    [a, 'Starting the line here ', "\n", b, 'and continuing here', "\n", 'to close', b, a, "\n\n"].join('')
+    [a, 'Starting the line here ', &quot;\n&quot;, b, 'and continuing here', &quot;\n&quot;, 'to close', b, a, &quot;\n\n&quot;].join('')
   end
 end
 

--- a/spec/html_examples/entities.html
+++ b/spec/html_examples/entities.html
@@ -25,7 +25,7 @@
 require 'org-ruby'
 
 Orgmode::HtmlEntities.each_pair do |entity, _|
-  puts "- Writing =\\#{entity}=, results in: \\#{entity}"
+  puts &quot;- Writing =\\#{entity}=, results in: \\#{entity}&quot;
 end
 </pre>
 <pre class="example">

--- a/spec/html_examples/properties_drawer.html
+++ b/spec/html_examples/properties_drawer.html
@@ -9,7 +9,7 @@ df \
 </pre>
 <h2>sort by the percent full</h2>
 <pre class="example">
-|awk '{print $5 " " $6}'|sort -n |tail -1 \
+|awk '{print $5 &quot; &quot; $6}'|sort -n |tail -1 \
 </pre>
 <h2>extract the mount point</h2>
 <pre class="example">


### PR DESCRIPTION
Hey!

Org-mode snippet `=http://<app>-<namespace>.rhcloud.com=` is converted as

``` html
<code>http://<app>-<namespace>.rhcloud.com</code>
```

whereas it should be

``` html
<code>http://&lt;app&gt;-&lt;namespace&gt;.rhcloud.com</code>
```

Best regards,
Vladimir.
