### PR TITLE
Include the properties drawer from a headline

### DIFF
--- a/lib/org-ruby/headline.rb
+++ b/lib/org-ruby/headline.rb
@@ -28,6 +28,9 @@ module Orgmode
     # The export state of this headline. See +ValidExportStates+.
     attr_accessor :export_state
 
+    # Include the property drawer items found for the headline
+    attr_accessor :property_drawer
+
     # This is the regex that matches a line
     LineRegexp = /^\*+\s+/
 
@@ -47,6 +50,7 @@ module Orgmode
       @body_lines = []
       @tags = []
       @export_state = :exclude
+      @property_drawer = { }
       if (@line =~ LineRegexp) then
         @level = $&.strip.length + offset
         @headline_text = $'.strip

--- a/lib/org-ruby/line.rb
+++ b/lib/org-ruby/line.rb
@@ -66,6 +66,12 @@ module Orgmode
       @line =~ PropertyDrawerItemRegexp
     end
 
+    def property_drawer_item
+      @line =~ PropertyDrawerItemRegexp
+
+      [$1, $2]
+    end
+
     # Tests if a line contains metadata instead of actual content.
     def metadata?
       check_assignment_or_regexp(:metadata, /^\s*(CLOCK|DEADLINE|START|CLOSED|SCHEDULED):/)

--- a/lib/org-ruby/parser.rb
+++ b/lib/org-ruby/parser.rb
@@ -133,6 +133,10 @@ module Orgmode
           mode = :property_drawer if line.property_drawer_begin_block?
         end
 
+        if mode == :property_drawer and @current_headline
+          @current_headline.property_drawer[line.property_drawer_item.first] = line.property_drawer_item.last
+        end
+
         unless mode == :comment
           if @current_headline
             @current_headline.body_lines << line

--- a/lib/org-ruby/parser.rb
+++ b/lib/org-ruby/parser.rb
@@ -130,7 +130,7 @@ module Orgmode
           end
 
           mode = line.paragraph_type if line.begin_block?
-          mode = :property_drawer if line.property_drawer_begin_block?
+          mode = :property_drawer if previous_line and previous_line.property_drawer_begin_block?
         end
 
         if mode == :property_drawer and @current_headline

--- a/spec/data/freeform-example.org
+++ b/spec/data/freeform-example.org
@@ -20,6 +20,10 @@ This is my todo list, research file, and log record from working on
 the Freeform project.
 
 * Future ideas						:someday:
+  :PROPERTIES:
+  :DATE:     2009-11-26
+  :END:
+
   - Add *posts*
   - Enforce uniqueness of url_token
   - Add FeedSync support

--- a/spec/data/freeform-example.org
+++ b/spec/data/freeform-example.org
@@ -22,6 +22,7 @@ the Freeform project.
 * Future ideas						:someday:
   :PROPERTIES:
   :DATE:     2009-11-26
+  :SLUG:     future-ideas
   :END:
 
   - Add *posts*

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -33,8 +33,9 @@ describe Orgmode::Parser do
 
   it "should include the property drawer items from a headline" do
     parser = Orgmode::Parser.load(FreeformExampleFile)
-    parser.headlines.first.property_drawer.count.should > 0
+    parser.headlines.first.property_drawer.count.should == 2
     parser.headlines.first.property_drawer['DATE'].should == '2009-11-26'
+    parser.headlines.first.property_drawer['SLUG'].should == 'future-ideas'
   end
 
   it "should put body lines in headlines" do

--- a/spec/parser_spec.rb
+++ b/spec/parser_spec.rb
@@ -31,6 +31,12 @@ describe Orgmode::Parser do
     parser.headlines[1].level.should eql(2)
   end
 
+  it "should include the property drawer items from a headline" do
+    parser = Orgmode::Parser.load(FreeformExampleFile)
+    parser.headlines.first.property_drawer.count.should > 0
+    parser.headlines.first.property_drawer['DATE'].should == '2009-11-26'
+  end
+
   it "should put body lines in headlines" do
     parser = Orgmode::Parser.load(RememberFile)
     parser.headlines[0].should have(1).body_lines


### PR DESCRIPTION
This is to add the property drawer within a headline, useful for when having to extract this metadata.
