### PR TITLE
Link abbrev feature

### DIFF
--- a/lib/org-ruby/html_output_buffer.rb
+++ b/lib/org-ruby/html_output_buffer.rb
@@ -305,6 +305,7 @@ module Orgmode
         end
 
         if defi
+          link = @options[:link_abbrevs][link] if @options[:link_abbrevs].has_key? link
           "@<a href=\"#{link}\">#{defi}@</a>"
         else
           "@<img src=\"#{link}\" alt=\"#{link}\" />"

--- a/lib/org-ruby/line.rb
+++ b/lib/org-ruby/line.rb
@@ -224,6 +224,16 @@ module Orgmode
       end
     end
 
+    LinkAbbrevRegexp = /^\s*#\+LINK:\s*(\w+)\s+(.+)$/i
+
+    def link_abbrev?
+      @line =~ LinkAbbrevRegexp
+    end
+
+    def link_abbrev_data
+      [$1, $2] if @line =~ LinkAbbrevRegexp
+    end
+
     IncludeFileRegexp = /^\s*#\+INCLUDE:\s*"([^"]+)"(\s+([^\s]+)\s+(.*))?$/i
 
     def include_file?

--- a/lib/org-ruby/parser.rb
+++ b/lib/org-ruby/parser.rb
@@ -96,6 +96,7 @@ module Orgmode
       @header_lines = []
       @in_buffer_settings = { }
       @options = { }
+      @link_abbrevs = { }
 
       parse_lines @lines, offset
     end
@@ -137,6 +138,12 @@ module Orgmode
             include_lines = Orgmode::Parser.new(include_data).lines
             parse_lines include_lines, offset
           end
+        end
+
+        # Store link abbreviations
+        if line.link_abbrev?
+          link_abbrev_data = line.link_abbrev_data
+          @link_abbrevs[link_abbrev_data[0]] = link_abbrev_data[1]
         end
 
         mode = :normal if line.end_block? and mode == line.paragraph_type
@@ -256,7 +263,8 @@ module Orgmode
         :export_heading_number => export_heading_number?,
         :export_todo => export_todo?,
         :use_sub_superscripts =>  use_sub_superscripts?,
-        :export_footnotes => export_footnotes?
+        :export_footnotes => export_footnotes?,
+        :link_abbrevs => @link_abbrevs
       }
       export_options[:skip_tables] = true if not export_tables?
       output = ""

--- a/spec/html_examples/link-features.html
+++ b/spec/html_examples/link-features.html
@@ -22,3 +22,6 @@
   <li><a href="path.html">file:path.org label</a></li>
   <li><a href="notes/path.html">file:notes/path.org label</a></li>
 </ul>
+<h1>Links abbreviations</h1>
+<p>URLs can be abbreviated by a LINK definition in the org file</p>
+<p><a href="http://example.com/something">This is an abbreviated link example</a></p>

--- a/spec/html_examples/link-features.org
+++ b/spec/html_examples/link-features.org
@@ -33,3 +33,11 @@ sections within documents, etc.
 - [[file:path.org][file:path.org label]]
 
 - [[file:notes/path.org][file:notes/path.org label]]
+
+* Links abbreviations
+
+  URLs can be abbreviated by a LINK definition in the org file
+
+#+LINK: example http://example.com/something
+
+[[example][This is an abbreviated link example]]


### PR DESCRIPTION
Hi,

As requested in issue #52, I now manage link abbreviations.
Tell me if the logic is ok for you.

Here is an Org example:

```
#+LINK: example http://example.com/something
#+LINK: example2 http://example.com/something2

[[example][This an example]]
[[example2][This is the second example]]
[[http://example.com/standard][Standard example]]
```

this is the end 
