### PR TITLE
use HTTPS homepage URL in gemspec

### DIFF
--- a/org-ruby.gemspec
+++ b/org-ruby.gemspec
@@ -14,7 +14,7 @@ Gem::Specification.new do |s|
   s.executables = ["org-ruby"]
   s.extra_rdoc_files = ["History.txt", "README.rdoc", "bin/org-ruby"]
   s.files = ["History.txt", "README.rdoc", "bin/org-ruby", "lib/org-ruby.rb", "lib/org-ruby/headline.rb", "lib/org-ruby/html_output_buffer.rb", "lib/org-ruby/html_symbol_replace.rb", "lib/org-ruby/line.rb", "lib/org-ruby/output_buffer.rb", "lib/org-ruby/parser.rb", "lib/org-ruby/regexp_helper.rb", "lib/org-ruby/textile_output_buffer.rb", "lib/org-ruby/textile_symbol_replace.rb", "lib/org-ruby/tilt.rb"]
-  s.homepage = "http://github.com/bdewey/org-ruby"
+  s.homepage = "https://github.com/bdewey/org-ruby"
   s.rdoc_options = ["--main", "README.rdoc"]
   s.require_paths = ["lib"]
   s.rubyforge_project = "org-ruby"


### PR DESCRIPTION
GitHub supports HTTPS, so it's a good idea to use the secure protocol where possible.
