### PR TITLE
Backport CGI::escapeHTML function from the Ruby standard library

### DIFF
--- a/lib/org-ruby/html_output_buffer.rb
+++ b/lib/org-ruby/html_output_buffer.rb
@@ -1,4 +1,3 @@
-require 'cgi'
 begin
   require 'pygments'
 rescue LoadError
@@ -140,7 +139,7 @@ module Orgmode
           @new_paragraph = true
         else
           # *NOTE* Don't use escape_buffer! through its sensitivity to @<text> forms
-          @buffer = CGI::escapeHTML @buffer
+          @buffer = escapeHTML @buffer
         end
 
         # Whitespace is significant in :code mode. Always output the
@@ -275,7 +274,7 @@ module Orgmode
     def inline_formatting(str)
       @re_help.rewrite_emphasis str do |marker, s|
         if marker == "=" or marker == "~"
-          s = CGI::escapeHTML s
+          s = escapeHTML s
           "<#{Tags[marker][:open]}>#{s}</#{Tags[marker][:close]}>"
         else
           "@<#{Tags[marker][:open]}>#{s}@</#{Tags[marker][:close]}>"
@@ -370,6 +369,30 @@ module Orgmode
       @buffer.gsub! /^\s*(,)(\s*)([*]|#\+)/ do |match|
         "#{$2}#{$3}"
       end
+    end
+
+    # The CGI::escapeHTML function backported from the Ruby standard library
+    # as of commit fd2fc885b43283aa3d76820b2dfa9de19a77012f
+    #
+    # Implementation of the cgi module can change among Ruby versions
+    # so stabilizing on a single one here to avoid surprises.
+    #
+    # https://github.com/ruby/ruby/blob/trunk/lib/cgi/util.rb
+    #
+    # The set of special characters and their escaped values
+    TABLE_FOR_ESCAPE_HTML__ = {
+      "'" => '&#39;',
+      '&' => '&amp;',
+      '"' => '&quot;',
+      '<' => '&lt;',
+      '>' => '&gt;',
+    }
+    # Escape special characters in HTML, namely &\"<>
+    #   escapeHTML('Usage: foo "bar" <baz>')
+    #      # => "Usage: foo &quot;bar&quot; &lt;baz&gt;"
+    private
+    def escapeHTML(string)
+      string.gsub(/['&\"<>]/, TABLE_FOR_ESCAPE_HTML__)
     end
   end                           # class HtmlOutputBuffer
 end                             # module Orgmode

--- a/spec/html_code_syntax_highlight_examples/advanced-code-no-color.html
+++ b/spec/html_code_syntax_highlight_examples/advanced-code-no-color.html
@@ -47,7 +47,7 @@ user&gt; (take 20 fib-seq)
 </pre>
 <p>Even if no language is set, it is still wrapped in code tags but class is empty.</p>
 <pre class="src">
-echo 'Defaults env_keeps=&quot;http_proxy https_proxy ftp_proxy&quot;' | sudo tee -a /etc/sudoers
+echo &#39;Defaults env_keeps=&quot;http_proxy https_proxy ftp_proxy&quot;&#39; | sudo tee -a /etc/sudoers
 </pre>
 <h1><span class="heading-number heading-number-1">3</span> It should be possible to write a colon at the beginning of an example</h1>
 <blockquote>

--- a/spec/html_code_syntax_highlight_examples/src-code-list-no-color.html
+++ b/spec/html_code_syntax_highlight_examples/src-code-list-no-color.html
@@ -4,7 +4,7 @@
     <pre class="src" lang="ruby">
 class Hello
   def say
-    puts 'cheers'
+    puts &#39;cheers&#39;
   end
 end
     </pre>

--- a/spec/html_examples/code-lists.html
+++ b/spec/html_examples/code-lists.html
@@ -48,7 +48,7 @@
     <pre class="example">
 class Hello
   def say
-    puts 'cheers'
+    puts &#39;cheers&#39;
   end
 end
     </pre>

--- a/spec/html_examples/emphasis.html
+++ b/spec/html_examples/emphasis.html
@@ -34,7 +34,7 @@ emphasis_tests = [
 
 all = emphasis_tests.map do |a|
   emphasis_tests.map do |b|
-    [b, ' ', a, ' ', b, &quot;\n\n&quot;].join('')
+    [b, &#39; &#39;, a, &#39; &#39;, b, &quot;\n\n&quot;].join(&#39;&#39;)
   end
 end
 
@@ -46,8 +46,8 @@ emphasis_tests = [&quot;*&quot;,&quot;/&quot;,&quot;=&quot;,&quot;~&quot;,&quot;
 
 all = emphasis_tests.map do |a|
   emphasis_tests.map do |b|
-    [[a, 'Answer: ', b, '42', b, ' ',a, &quot;\n\n&quot;].join(''),
-     [a, 'Answer: ', b, '42', b, '',a, &quot;\n\n&quot;].join('')].flatten
+    [[a, &#39;Answer: &#39;, b, &#39;42&#39;, b, &#39; &#39;,a, &quot;\n\n&quot;].join(&#39;&#39;),
+     [a, &#39;Answer: &#39;, b, &#39;42&#39;, b, &#39;&#39;,a, &quot;\n\n&quot;].join(&#39;&#39;)].flatten
   end
 end
 
@@ -131,7 +131,7 @@ emphasis_tests = [&quot;*&quot;,&quot;/&quot;,&quot;=&quot;,&quot;~&quot;,&quot;
 
 all = emphasis_tests.map do |a|
   emphasis_tests.map do |b|
-    [a, 'Starting the line here ', &quot;\n&quot;, b, 'and continuing here to close', b, a, &quot;\n\n&quot;].join('')
+    [a, &#39;Starting the line here &#39;, &quot;\n&quot;, b, &#39;and continuing here to close&#39;, b, a, &quot;\n\n&quot;].join(&#39;&#39;)
   end
 end
 
@@ -215,7 +215,7 @@ emphasis_tests = [&quot;*&quot;,&quot;/&quot;,&quot;=&quot;,&quot;~&quot;,&quot;
 
 all = emphasis_tests.map do |a|
   emphasis_tests.map do |b|
-    [a, 'Starting the line here ', &quot;\n&quot;, b, 'and continuing here', &quot;\n&quot;, 'to close', b, a, &quot;\n\n&quot;].join('')
+    [a, &#39;Starting the line here &#39;, &quot;\n&quot;, b, &#39;and continuing here&#39;, &quot;\n&quot;, &#39;to close&#39;, b, a, &quot;\n\n&quot;].join(&#39;&#39;)
   end
 end
 

--- a/spec/html_examples/entities.html
+++ b/spec/html_examples/entities.html
@@ -11,7 +11,7 @@
   able &delta; to &eta; exist &theta; in &epsilon;
   the same line &radic; &raquo;.</p>
 <pre class="example">
-\laquo They won't appear in in example blocks. \raquo
+\laquo They won&#39;t appear in in example blocks. \raquo
 </pre>
 <div style="text-align: center">
   <p>&lceil; &mdash; &mdash; &mdash; &mdash; &mdash; &mdash; &rceil;</p>
@@ -22,7 +22,7 @@
 <h1>List of entities supported</h1>
 <pre class="example">
 # Script to generate the list of currently supported entities
-require 'org-ruby'
+require &#39;org-ruby&#39;
 
 Orgmode::HtmlEntities.each_pair do |entity, _|
   puts &quot;- Writing =\\#{entity}=, results in: \\#{entity}&quot;

--- a/spec/html_examples/properties_drawer.html
+++ b/spec/html_examples/properties_drawer.html
@@ -5,15 +5,15 @@ df \
 </pre>
 <h2>strip the header row</h2>
 <pre class="example">
-|sed '1d' \
+|sed &#39;1d&#39; \
 </pre>
 <h2>sort by the percent full</h2>
 <pre class="example">
-|awk '{print $5 &quot; &quot; $6}'|sort -n |tail -1 \
+|awk &#39;{print $5 &quot; &quot; $6}&#39;|sort -n |tail -1 \
 </pre>
 <h2>extract the mount point</h2>
 <pre class="example">
-|awk '{print $2}'
+|awk &#39;{print $2}&#39;
 </pre>
 <h1>Properties drawer example</h1>
 <p>These properties are metadata so they should not be visible.</p>


### PR DESCRIPTION
The CGI::escapeHTML function backported from the Ruby standard library
as of commit fd2fc885b43283aa3d76820b2dfa9de19a77012f

Implementation of the cgi module can change among Ruby versions
so stabilizing on a single one here to avoid surprises.

https://github.com/ruby/ruby/blob/trunk/lib/cgi/util.rb
