### PR TITLE
Add support for begin_export html

### DIFF
--- a/lib/org-ruby/html_output_buffer.rb
+++ b/lib/org-ruby/html_output_buffer.rb
@@ -134,7 +134,7 @@ module Orgmode
               @buffer = CodeRay.scan(@buffer, 'text').html(:wrap => nil, :css => :style)
             end
           end
-        when (current_mode == :html or current_mode == :raw_text)
+        when (current_mode == :html or (current_mode == :export and @block_lang == "html") or current_mode == :raw_text)
           @buffer.gsub!(/\A\n/, "") if @new_paragraph == :start
           @new_paragraph = true
         else

--- a/lib/org-ruby/line.rb
+++ b/lib/org-ruby/line.rb
@@ -268,7 +268,7 @@ module Orgmode
         :metadata
       when block_type
         case block_type.downcase.to_sym
-        when :center, :comment, :example, :html, :quote, :src
+        when :center, :comment, :example, :html, :quote, :src, :export
           block_type.downcase.to_sym
         else
           :comment

--- a/lib/org-ruby/output_buffer.rb
+++ b/lib/org-ruby/output_buffer.rb
@@ -127,7 +127,7 @@ module Orgmode
 
     # Test if we're in an output mode in which whitespace is significant.
     def preserve_whitespace?
-      [:example, :inline_example, :raw_text, :src].include? current_mode
+      [:example, :inline_example, :raw_text, :src, :export].include? current_mode
     end
 
     ######################################################################

--- a/lib/org-ruby/parser.rb
+++ b/lib/org-ruby/parser.rb
@@ -100,7 +100,7 @@ module Orgmode
       @parser_options = parser_options
 
       #
-      # Include file feature disabled by default since 
+      # Include file feature disabled by default since
       # it would be dangerous in some environments
       #
       # http://orgmode.org/manual/Include-files.html
@@ -182,7 +182,7 @@ module Orgmode
           end
           table_header_set = false if !line.table?
 
-        when :example, :html, :src
+        when :example, :html, :src, :export
           # As long as we stay in code mode, force lines to be code.
           # Don't try to interpret structural items, like headings and tables.
           line.assigned_paragraph_type = :code


### PR DESCRIPTION
As described by Bastien Guerry in https://github.com/bdewey/org-ruby/issues/73 , we need to support `#+begin_export html`.

Here is the code to do so!

Thanks